### PR TITLE
Remove encoding_string access in constructor

### DIFF
--- a/include/ConformalTracking.h
+++ b/include/ConformalTracking.h
@@ -163,7 +163,6 @@ protected:
   int m_minClustersOnTrack;
   bool m_debugPlots;
   KDCluster* debugSeed;
-  std::string m_decoderString;
 	
 } ;
 

--- a/src/ConformalTracking.cc
+++ b/src/ConformalTracking.cc
@@ -111,7 +111,6 @@ ConformalTracking::ConformalTracking() : Processor("ConformalTracking") {
   registerProcessorParameter( "MaxDistance",				"Maximum length of a cell (max. distance between two hits)", 	m_maxDistance, 				double(0.015) 	);
   registerProcessorParameter( "MaxChi2",						"Maximum chi2/ndof for linear conformal tracks", 							m_chi2cut, 						double(300.) 	);
   registerProcessorParameter( "MinClustersOnTrack", "Minimum number of clusters to create a track", 							m_minClustersOnTrack, int(6)				);
-  registerProcessorParameter( "CellIDDecoderString","Decoding string used for Cell ID calculation", 							m_decoderString, 			std::string(lcio::LCTrackerCellID::encoding_string()));
 
 }
 
@@ -319,7 +318,7 @@ void ConformalTracking::processEvent( LCEvent* evt ) {
   trackCollection->setFlag( trkFlag.getFlag()  ) ;
   
   // Set up ID decoder
-  UTIL::BitField64 m_encoder( m_decoderString ) ;
+  UTIL::BitField64 m_encoder( lcio::LCTrackerCellID::encoding_string() );
 
   /*
    Debug plotting. This section picks up tracks reconstructed using the cheated pattern recognition (TruthTrackFinder) and uses it to show


### PR DESCRIPTION

BEGINRELEASENOTES
- Removed "CellIDDecoderString" parameter, not necessary by using encoding_string()

ENDRELEASENOTES