### PR TITLE
all seed collections considered with previously unused hits, rather t…

### DIFF
--- a/src/ConformalTracking.cc
+++ b/src/ConformalTracking.cc
@@ -577,13 +577,13 @@ void ConformalTracking::processEvent( LCEvent* evt ) {
     // The set of conformal hits which will be considered in this iteration
     std::vector<KDCluster*> kdClusters;
 
-    if(collection < seedCollections){
-      std::vector<KDCluster*> clusters = collectionClusters[collection]; //this makes a copy FIX ME
-      int nhits = clusters.size();
-      for(int hit=0;hit<nhits;hit++){
-        kdClusters.push_back(clusters[hit]);
-      }
-    }else{
+//    if(collection < seedCollections){
+//      std::vector<KDCluster*> clusters = collectionClusters[collection]; //this makes a copy FIX ME
+//      int nhits = clusters.size();
+//      for(int hit=0;hit<nhits;hit++){
+//        kdClusters.push_back(clusters[hit]);
+//      }
+//    }else{
       // Add hits from this and previous collections to the list
     	for(unsigned int col=0;col<collection;col++){
         std::vector<KDCluster*> clusters = collectionClusters[col]; //this makes a copy FIX ME
@@ -593,7 +593,7 @@ void ConformalTracking::processEvent( LCEvent* evt ) {
           kdClusters.push_back(clusters[hit]);
         }
       }
-    }
+//    }
     
     // Sort the KDClusters from larger to smaller radius
     if(kdClusters.size() == 0) continue;


### PR DESCRIPTION
…han first individually



BEGINRELEASENOTES
- Collections are added sequentially to the list of hits being used to make tracks, including unused hits from the previous collections. Previously hits were considered individually before this step, leading to missed hits in the interaction region.
ENDRELEASENOTES