### PR TITLE
Adding clang-format to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,3 +104,14 @@ INSTALL_SHARED_LIBRARY( ${PROJECT_NAME} DESTINATION lib )
 # display some variables and write them to cache
 DISPLAY_STD_VARIABLES()
 
+
+### FORMATTING ##############################################################
+# Set the source files to clang-format (FIXME: determine this betteru
+FILE(GLOB_RECURSE
+     CHECK_CXX_SOURCE_FILES
+        src/*.cc src/*.C include/*.h
+     )
+INCLUDE("cmake/clang-cpp-checks.cmake")
+
+
+

--- a/cmake/clang-cpp-checks.cmake
+++ b/cmake/clang-cpp-checks.cmake
@@ -1,0 +1,37 @@
+# Additional targets to perform clang-format/clang-tidy
+
+# Get all project files - FIXME: this should also use the list of generated targets
+IF(NOT CHECK_CXX_SOURCE_FILES)
+    MESSAGE(FATAL_ERROR "Variable CHECK_CXX_SOURCE_FILES not defined - set it to the list of files to auto-format")
+    RETURN()
+ENDIF()
+
+# Adding clang-format check and formatter if found
+FIND_PROGRAM(CLANG_FORMAT "clang-format")
+IF(CLANG_FORMAT)
+    ADD_CUSTOM_TARGET(
+        format
+        COMMAND
+        ${CLANG_FORMAT}
+        -i
+        -style=file
+        ${CHECK_CXX_SOURCE_FILES}
+        COMMENT "Auto formatting of all source files"
+    )
+
+    ADD_CUSTOM_TARGET(
+        check-format
+        COMMAND
+        ${CLANG_FORMAT}
+        -style=file
+        -output-replacements-xml
+        ${CHECK_CXX_SOURCE_FILES} 
+        # print output
+        | tee ${CMAKE_BINARY_DIR}/check_format_file.txt | grep -c "replacement " | 
+                tr -d "[:cntrl:]" && echo " replacements necessary"
+        # WARNING: fix to stop with error if there are problems
+        COMMAND ! grep -c "replacement " 
+                  ${CMAKE_BINARY_DIR}/check_format_file.txt > /dev/null
+        COMMENT "Checking format compliance"
+    )
+ENDIF()

--- a/include/ConformalTracking.h
+++ b/include/ConformalTracking.h
@@ -164,6 +164,7 @@ protected:
   // Other constants
   double     m_thetaRange;
   double     m_chi2cut;
+  double     m_chi2increase;
   double     m_maxCellAngle;
   double     m_maxCellAngleRZ;
   double     m_maxDistance;
@@ -222,4 +223,6 @@ bool sort_by_cellWeight(Cell* cell1, Cell* cell2) {
 // Sort kdtracks from longest to shortest
 bool sort_by_length(KDTrack* track1, KDTrack* track2) { return (track1->m_clusters.size() > track2->m_clusters.size()); }
 
+// Sort kdtracks from lowest to highest pt
+bool sort_by_pt(KDTrack* track1, KDTrack* track2) { return (track1->pt() < track2->pt()); }
 #endif

--- a/src/ConformalTracking.cc
+++ b/src/ConformalTracking.cc
@@ -1725,9 +1725,8 @@ double ConformalTracking::checkReal(KDTrack* track, std::map<KDCluster*, MCParti
   // Calculate the purity
   double purity = bestHits / nHits;
   streamlog_out(DEBUG) << "Number of hits on track: " << nHits << ". Good hits: " << bestHits << ". Purity: " << purity
-                       << ". Pt: "
-                       << sqrt(bestParticle->getMomentum()[0] * bestParticle->getMomentum()[0] +
-                               bestParticle->getMomentum()[1] * bestParticle->getMomentum()[1])
+                       << ". Pt: " << sqrt(bestParticle->getMomentum()[0] * bestParticle->getMomentum()[0] +
+                                           bestParticle->getMomentum()[1] * bestParticle->getMomentum()[1])
                        << ". Track chi2/ndof: " << track->chi2ndof() << ". Chi2/ndof in SZ fit: " << track->chi2ndofZS()
                        << std::endl;
 

--- a/src/ConformalTracking.cc
+++ b/src/ConformalTracking.cc
@@ -1747,8 +1747,8 @@ double ConformalTracking::checkReal(KDTrack* track, std::map<KDCluster*, MCParti
   mc_helper.SetPxPyPzE(bestParticle->getMomentum()[0], bestParticle->getMomentum()[1], bestParticle->getMomentum()[2],
                        bestParticle->getEnergy());
 
-  std::cout << "Particle at theta = " << mc_helper.Theta() * 180. / M_PI << ", with pt = " << mc_helper.Pt()
-            << ". pt estimate: " << track->pt() << std::endl;
+  streamlog_out(DEBUG7) << "Particle at theta = " << mc_helper.Theta() * 180. / M_PI << ", with pt = " << mc_helper.Pt()
+                        << ". pt estimate: " << track->pt() << std::endl;
 
   // Check if any hits are missing
   std::vector<KDCluster*> mcHits     = MCparticleHits[bestParticle];

--- a/src/ConformalTracking.cc
+++ b/src/ConformalTracking.cc
@@ -617,8 +617,8 @@ void ConformalTracking::processEvent(LCEvent* evt) {
 	//*/
 
   // Now make "real" tracks from all of the conformal tracks
-  streamlog_out(DEBUG) << "*** CA has made " << conformalTracksFinal.size()
-                       << (conformalTracksFinal.size() == 1 ? " track ***" : " tracks ***") << std::endl;
+  streamlog_out(DEBUG7) << "*** CA has made " << conformalTracksFinal.size()
+                        << (conformalTracksFinal.size() == 1 ? " track ***" : " tracks ***") << std::endl;
 
   // Loop over all track candidates
   for (unsigned int caTrack = 0; caTrack < conformalTracksFinal.size(); caTrack++) {
@@ -664,17 +664,16 @@ void ConformalTracking::processEvent(LCEvent* evt) {
 
     // Check track quality - if fit fails chi2 will be 0. For the moment add hits by hand to any track that fails the track fit, and store it as if it were ok...
     if (track->getChi2() == 0.) {
-      streamlog_out(DEBUG) << "Fit failed. Track has " << track->getTrackerHits().size() << " hits" << std::endl;
-      streamlog_out(DEBUG) << "Fit fail error " << fitError << std::endl;
-      // for(unsigned int p=0;p<trackHits.size();p++){
-      //   track->addHit(trackHits[p]);
-      // }
-      //    }//
-      //    delete marlinTrack;
+      streamlog_out(DEBUG7) << "Fit failed. Track has " << track->getTrackerHits().size() << " hits" << std::endl;
+      streamlog_out(DEBUG7) << "Fit fail error " << fitError << std::endl;
       delete track;
       delete marlinTrack;
       continue;
     }
+
+    /*for(unsigned int p=0;p<trackHits.size();p++){
+      track->addHit(trackHits[p]);
+    }*/
 
     // Add hit information TODO: this is just a fudge for the moment, since we only use vertex hits. Should do for each subdetector once enabled
     track->subdetectorHitNumbers().resize(2 * lcio::ILDDetID::ETD);
@@ -690,7 +689,7 @@ void ConformalTracking::processEvent(LCEvent* evt) {
       KDTrack* debugTrack = conformalTracksFinal[itrack];
 
       m_conformalChi2->Fill(debugTrack->chi2ndof());
-      streamlog_out(DEBUG) << "-------------------- New TRACK --------------------" << std::endl;
+      streamlog_out(DEBUG7) << "-------------------- New TRACK --------------------" << std::endl;
       double purity = checkReal(debugTrack, kdParticles, reconstructed, particleHits);
       if (purity >= m_purity) {
         m_conformalChi2real->Fill(debugTrack->chi2ndof());
@@ -751,11 +750,11 @@ void ConformalTracking::processEvent(LCEvent* evt) {
       if (mcParticle->getGeneratorStatus() != 1)
         continue;
       // Check if it was reconstructed
-      streamlog_out(DEBUG) << "-------------------- New PARTICLE --------------------" << std::endl;
+      streamlog_out(DEBUG7) << "-------------------- New PARTICLE --------------------" << std::endl;
       // List the pt
       double particlePt = sqrt(mcParticle->getMomentum()[0] * mcParticle->getMomentum()[0] +
                                mcParticle->getMomentum()[1] * mcParticle->getMomentum()[1]);
-      streamlog_out(DEBUG) << "Particle pt: " << particlePt << std::endl;
+      streamlog_out(DEBUG7) << "Particle pt: " << particlePt << std::endl;
       checkReconstructionFailure(mcParticle, particleHits, nearestNeighbours);
       if (reconstructed.count(mcParticle)) {
         nReconstructed++;
@@ -766,15 +765,15 @@ void ConformalTracking::processEvent(LCEvent* evt) {
       for (int iHit = 0; iHit < (mcHits.size() - 1); iHit++) {
         drawline(mcHits[iHit], mcHits[iHit + 1], iHit + 1);
       }
-      streamlog_out(DEBUG) << "Unreconstructed particle pt: " << particlePt << std::endl;
+      streamlog_out(DEBUG7) << "Unreconstructed particle pt: " << particlePt << std::endl;
       nUnreconstructed++;
 
       // Check why particles were not reconstructed
       //      checkReconstructionFailure(mcParticle, particleHits, used, nearestNeighbours);
     }
-    streamlog_out(DEBUG) << "Reconstructed " << nReconstructed << " particles out of " << nReconstructed + nUnreconstructed
-                         << ". Gives efficiency "
-                         << 100. * (double)nReconstructed / (double)(nReconstructed + nUnreconstructed) << "%" << std::endl;
+    streamlog_out(DEBUG7) << "Reconstructed " << nReconstructed << " particles out of " << nReconstructed + nUnreconstructed
+                          << ". Gives efficiency "
+                          << 100. * (double)nReconstructed / (double)(nReconstructed + nUnreconstructed) << "%" << std::endl;
     delete nearestNeighbours;
   }
 
@@ -835,7 +834,7 @@ void ConformalTracking::combineCollections(std::vector<KDCluster*>& kdClusters, 
 // Take a collection of hits and try to produce tracks out of them
 void ConformalTracking::buildNewTracks(std::vector<KDTrack*>& conformalTracks, std::vector<KDCluster*>& collection,
                                        KDTree* nearestNeighbours, bool radialSearch) {
-  streamlog_out(DEBUG) << "BUILDING new tracks" << std::endl;
+  streamlog_out(DEBUG7) << "BUILDING new tracks" << std::endl;
 
   // Sort the input collection by radius
   std::sort(collection.begin(), collection.end(), sort_by_radiusKD);
@@ -846,7 +845,7 @@ void ConformalTracking::buildNewTracks(std::vector<KDTrack*>& conformalTracks, s
     // Get the kdHit and check if it has already been used (assigned to a track)
     KDCluster* kdhit = collection[nKDHit];
     if (debugSeed && kdhit == debugSeed)
-      streamlog_out(DEBUG) << "Starting to seed with debug cluster" << std::endl;
+      streamlog_out(DEBUG7) << "Starting to seed with debug cluster" << std::endl;
     if (kdhit->used())
       continue;
     //      if(kdhit->getR() < 0.003) break; // new cut - once we get to inner radius we will never make tracks. temp? TODO: make parameter? FCC (0.005 to 0.003)
@@ -870,7 +869,7 @@ void ConformalTracking::buildNewTracks(std::vector<KDTrack*>& conformalTracks, s
 
     // Sort the neighbours from outer to inner radius
     if (debugSeed && kdhit == debugSeed)
-      streamlog_out(DEBUG) << "- picked up " << results.size() << " neighbours from theta search" << std::endl;
+      streamlog_out(DEBUG7) << "- picked up " << results.size() << " neighbours from theta search" << std::endl;
     if (results.size() == 0)
       continue;
     std::sort(results.begin(), results.end(), sort_by_radiusKD);
@@ -901,8 +900,8 @@ void ConformalTracking::buildNewTracks(std::vector<KDTrack*>& conformalTracks, s
       Cell* cell = new Cell(kdhit, nhit);
       cells.push_back(cell);
       if (debugSeed && kdhit == debugSeed)
-        streamlog_out(DEBUG) << "- made cell with neighbour " << neighbour << " at " << nhit->getU() << "," << nhit->getV()
-                             << std::endl;
+        streamlog_out(DEBUG7) << "- made cell with neighbour " << neighbour << " at " << nhit->getU() << "," << nhit->getV()
+                              << std::endl;
 
       // Debug plotting
       if (m_debugPlots && m_eventNumber == 0) {
@@ -912,7 +911,7 @@ void ConformalTracking::buildNewTracks(std::vector<KDTrack*>& conformalTracks, s
     }
 
     if (debugSeed && kdhit == debugSeed)
-      streamlog_out(DEBUG) << "- produced " << cells.size() << " seed cells" << std::endl;
+      streamlog_out(DEBUG7) << "- produced " << cells.size() << " seed cells" << std::endl;
 
     // No seed cells produced
     if (cells.size() == 0)
@@ -940,7 +939,7 @@ void ConformalTracking::buildNewTracks(std::vector<KDTrack*>& conformalTracks, s
     for (int itCell = 0; itCell < nCells; itCell++) {
       // Check if this cell has already been used
       if (debugSeed && kdhit == debugSeed)
-        streamlog_out(DEBUG) << "-- looking at cell " << itCell << std::endl;
+        streamlog_out(DEBUG7) << "-- looking at cell " << itCell << std::endl;
       if (usedCells.count(cells[itCell]))
         continue;
 
@@ -973,9 +972,9 @@ void ConformalTracking::buildNewTracks(std::vector<KDTrack*>& conformalTracks, s
       }
 
       // Look at the candidate tracks and fit them (+pick the best chi2/ndof)
-      //       streamlog_out(DEBUG)<<"- produced "<<candidateTracks.size()<<" candidate tracks"<<std::endl;
+      //       streamlog_out(DEBUG7)<<"- produced "<<candidateTracks.size()<<" candidate tracks"<<std::endl;
       if (debugSeed && kdhit == debugSeed)
-        streamlog_out(DEBUG) << "- produced " << candidateTracks.size() << " candidate tracks" << std::endl;
+        streamlog_out(DEBUG7) << "- produced " << candidateTracks.size() << " candidate tracks" << std::endl;
       if (candidateTracks.size() == 0)
         continue;
       std::vector<double>   chi2ndof;
@@ -990,7 +989,7 @@ void ConformalTracking::buildNewTracks(std::vector<KDTrack*>& conformalTracks, s
 
     // All tracks leading back to the seed hit have now been found. Decide which are the feasible candidates (may be more than 1)
     if (debugSeed && kdhit == debugSeed)
-      streamlog_out(DEBUG) << "== final number of candidate tracks to this seed hit: " << cellTracks.size() << std::endl;
+      streamlog_out(DEBUG7) << "== final number of candidate tracks to this seed hit: " << cellTracks.size() << std::endl;
     if (cellTracks.size() == 0) {
       // Clean up
       for (unsigned int itCell = 0; itCell < cells.size(); itCell++)
@@ -1000,11 +999,11 @@ void ConformalTracking::buildNewTracks(std::vector<KDTrack*>& conformalTracks, s
 
     std::vector<KDTrack*> bestTracks = cellTracks;  //CHANGE ME - temp to give all tracks
     //      std::vector<KDTrack*> bestTracks = getLowestChi2(cellTracks,cellTracksChi2ndof,chi2ndof);
-    //     streamlog_out(DEBUG)<<"== final number of stored tracks to this seed hit: "<<bestTracks.size()<<std::endl;
+    //     streamlog_out(DEBUG7)<<"== final number of stored tracks to this seed hit: "<<bestTracks.size()<<std::endl;
     if (debugSeed && kdhit == debugSeed) {
-      streamlog_out(DEBUG) << "== final number of stored tracks to this seed hit: " << bestTracks.size() << std::endl;
+      streamlog_out(DEBUG7) << "== final number of stored tracks to this seed hit: " << bestTracks.size() << std::endl;
       for (int itBest = 0; itBest < bestTracks.size(); itBest++)
-        streamlog_out(DEBUG) << "- track " << itBest << " has chi2/ndof " << bestTracks[itBest]->chi2ndof() << std::endl;
+        streamlog_out(DEBUG7) << "- track " << itBest << " has chi2/ndof " << bestTracks[itBest]->chi2ndof() << std::endl;
     }
 
     // Could now think to do the full helix fit and apply a chi2 cut. TODO
@@ -1093,10 +1092,10 @@ void ConformalTracking::buildNewTracks(std::vector<KDTrack*>& conformalTracks, s
         conformalTracks.push_back(bestTracks[itTrack]);
         bestTrackUsed = true;
         if (debugSeed && kdhit == debugSeed)
-          streamlog_out(DEBUG) << "== Pushing back best track with chi2/ndof " << bestTracks[itTrack]->chi2ndof()
-                               << std::endl;
+          streamlog_out(DEBUG7) << "== Pushing back best track with chi2/ndof " << bestTracks[itTrack]->chi2ndof()
+                                << std::endl;
         else
-          streamlog_out(DEBUG) << "Pushing back best track with chi2/ndof " << bestTracks[itTrack]->chi2ndof() << std::endl;
+          streamlog_out(DEBUG7) << "Pushing back best track with chi2/ndof " << bestTracks[itTrack]->chi2ndof() << std::endl;
       }
 
       if (not bestTrackUsed) {
@@ -1119,7 +1118,7 @@ void ConformalTracking::extendTracks(std::vector<KDTrack*>& conformalTracks, std
   // hit in the collection to every track, and keep the ones thta have a good chi2. In fact, it will extrapolate
   // the track and do a nearest neighbours search, but this seemed to fail for some reason, TODO!
 
-  streamlog_out(DEBUG) << "EXTENDING tracks" << std::endl;
+  streamlog_out(DEBUG7) << "EXTENDING tracks" << std::endl;
   if (collection.size() == 0)
     return;
   int nTracks = conformalTracks.size();
@@ -1155,12 +1154,12 @@ void ConformalTracking::extendTracks(std::vector<KDTrack*>& conformalTracks, std
     std::sort(collection.begin(), collection.end(), sort_by_layer);
 
     unsigned int nKDHits = collection.size();
-    //streamlog_out(DEBUG)<<"STARTING"<<std::endl;
+    //streamlog_out(DEBUG7)<<"STARTING"<<std::endl;
     //      for(int newHit=0;newHit<results2.size();newHit++){
     for (unsigned int nKDHit = 0; nKDHit < nKDHits; nKDHit++) {
       // Get the kdHit and check if it has already been used (assigned to a track)
       KDCluster* kdhit = collection[nKDHit];
-      //streamlog_out(DEBUG)<<"Detector "<<kdhit->getSubdetector()<<", layer "<<kdhit->getLayer()<<", side "<<kdhit->getSide()<<std::endl;
+      //streamlog_out(DEBUG7)<<"Detector "<<kdhit->getSubdetector()<<", layer "<<kdhit->getLayer()<<", side "<<kdhit->getSide()<<std::endl;
 
       // If this hit is on a new layer, then add the hit from the previous layer and start anew
       if (bestCluster != NULL && !(kdhit->sameLayer(bestCluster))) {
@@ -1246,26 +1245,26 @@ void ConformalTracking::extendSeedCells(std::vector<Cell*>& cells, KDTree* neare
       delete fakeHit;
 
       if (extendingTrack)
-        streamlog_out(DEBUG) << "Found " << results.size() << " neighbours from cell extrapolation" << std::endl;
+        streamlog_out(DEBUG7) << "Found " << results.size() << " neighbours from cell extrapolation" << std::endl;
       // Make new cells pointing inwards
       for (unsigned int neighbour = 0; neighbour < results.size(); neighbour++) {
         if (extendingTrack)
-          streamlog_out(DEBUG) << "looking at neighbour " << neighbour << std::endl;
+          streamlog_out(DEBUG7) << "looking at neighbour " << neighbour << std::endl;
         // Get the neighbouring hit
         KDCluster* nhit = results[neighbour];
 
         // Check that it is not used, is not on the same detector layer, points inwards and has real z pointing away from IP
-        //        if(used.count(nhit)){if(extendingTrack)streamlog_out(DEBUG)<<"- used"<<std::endl; continue;}
+        //        if(used.count(nhit)){if(extendingTrack)streamlog_out(DEBUG7)<<"- used"<<std::endl; continue;}
         if (nhit->used())
           continue;
         if (hit->sameLayer(nhit)) {
           if (extendingTrack)
-            streamlog_out(DEBUG) << "- same layer" << std::endl;
+            streamlog_out(DEBUG7) << "- same layer" << std::endl;
           continue;
         }
         if (nhit->getR() >= hit->getR()) {
           if (extendingTrack)
-            streamlog_out(DEBUG) << "- higher radius" << std::endl;
+            streamlog_out(DEBUG7) << "- higher radius" << std::endl;
           continue;
         }
 
@@ -1351,23 +1350,23 @@ void ConformalTracking::createTracksNew(std::vector<cellularTrack*>& finalcellul
   // Now start to follow all paths back from this seed cell
   // While there are still tracks that are not finished (last cell weight 0), keep following their path
   while (toBeUpdated(cellularTracks)) {
-    //   streamlog_out(DEBUG)<<"== Updating "<<cellularTracks.size()<<" tracks"<<std::endl;
+    //   streamlog_out(DEBUG7)<<"== Updating "<<cellularTracks.size()<<" tracks"<<std::endl;
     // Loop over all (currently existing) tracks
     int nTracks = cellularTracks.size();
     for (int itTrack = 0; itTrack < nTracks; itTrack++) {
       // If the track is finished, do nothing
       //      if(cellularTracks[itTrack].back()->getWeight() == 0) continue;
       if (cellularTracks[itTrack]->back()->getFrom()->size() == 0) {
-        //       streamlog_out(DEBUG)<<"-- Track "<<itTrack<<" is finished"<<std::endl;
+        //       streamlog_out(DEBUG7)<<"-- Track "<<itTrack<<" is finished"<<std::endl;
         continue;
       }
 
       // While there is only one path leading from this cell, follow that path
       Cell* cell = cellularTracks[itTrack]->back();
-      //     streamlog_out(DEBUG)<<"-- Track "<<itTrack<<" has "<<(*(cell->getFrom())).size()<<" cells attached to the end of it"<<std::endl;
+      //     streamlog_out(DEBUG7)<<"-- Track "<<itTrack<<" has "<<(*(cell->getFrom())).size()<<" cells attached to the end of it"<<std::endl;
       //      while(cell->getWeight() > 0 && (*(cell->getFrom())).size() == 1){
       while ((*(cell->getFrom())).size() == 1) {
-        //       streamlog_out(DEBUG)<<"- simple extension"<<std::endl;
+        //       streamlog_out(DEBUG7)<<"- simple extension"<<std::endl;
         // Get the cell that it attaches to
         Cell* parentCell = (*(cell->getFrom()))[0];
         // Attach it to the track and continue
@@ -1383,7 +1382,7 @@ void ConformalTracking::createTracksNew(std::vector<cellularTrack*>& finalcellul
       // If the weight is != 0 and there is more than one path to follow, branch the track (create a new one for each path)
       int nBranches = (*(cell->getFrom())).size();
 
-      //     streamlog_out(DEBUG)<<"- making "<<nBranches<<" branches"<<std::endl;
+      //     streamlog_out(DEBUG7)<<"- making "<<nBranches<<" branches"<<std::endl;
 
       // For each additional branch make a new track
       for (int itBranch = 1; itBranch < nBranches; itBranch++) {
@@ -1576,21 +1575,21 @@ void ConformalTracking::extendTrack(KDTrack* track, std::vector<cellularTrack*> 
   vector<KDCluster*> finalHits;
   double             bestChi2Conformal, bestChi2ZS;
 
-  //  for(int i=0;i<track->clusters().size();i++)streamlog_out(DEBUG)<<"- cluster "<<i<<" has u,v "<<track->clusters()[i]->getU()<<","<<track->clusters()[i]->getV()<<std::endl;
+  //  for(int i=0;i<track->clusters().size();i++)streamlog_out(DEBUG7)<<"- cluster "<<i<<" has u,v "<<track->clusters()[i]->getU()<<","<<track->clusters()[i]->getV()<<std::endl;
 
   for (int nTrackExtension = 0; nTrackExtension < trackSegments.size(); nTrackExtension++) {
-    //   streamlog_out(DEBUG)<<"Track extension "<<nTrackExtension<<std::endl;
+    //   streamlog_out(DEBUG7)<<"Track extension "<<nTrackExtension<<std::endl;
     vector<KDCluster*> newHits;
 
     // Add each of the new clusters
     KDCluster* kdStart = (*trackSegments[nTrackExtension])[0]->getEnd();
     newHits.push_back(kdStart);
-    //   streamlog_out(DEBUG)<<"- cluster "<<" has u,v "<<kdStart->getU()<<","<<kdStart->getV()<<std::endl;
+    //   streamlog_out(DEBUG7)<<"- cluster "<<" has u,v "<<kdStart->getU()<<","<<kdStart->getV()<<std::endl;
 
     for (unsigned int trackCell = 0; trackCell < trackSegments[nTrackExtension]->size() - 2; trackCell++) {
       KDCluster* kdEnd = (*trackSegments[nTrackExtension])[trackCell]->getStart();
       newHits.push_back(kdEnd);
-      //     streamlog_out(DEBUG)<<"- cluster "<<" has u,v "<<kdEnd->getU()<<","<<kdEnd->getV()<<std::endl;
+      //     streamlog_out(DEBUG7)<<"- cluster "<<" has u,v "<<kdEnd->getU()<<","<<kdEnd->getV()<<std::endl;
     }
 
     double newChi2Conformal, newChi2ZS;
@@ -1616,7 +1615,7 @@ void ConformalTracking::extendTrack(KDTrack* track, std::vector<cellularTrack*> 
     }
     track->linearRegression();
     track->linearRegressionConformal();
-    //   streamlog_out(DEBUG)<<"- new chi2/ndof: "<<track->chi2ndof()<<", chi2ZS/ndof: "<<track->chi2ndofZS()<<std::endl;
+    //   streamlog_out(DEBUG7)<<"- new chi2/ndof: "<<track->chi2ndof()<<", chi2ZS/ndof: "<<track->chi2ndofZS()<<std::endl;
   }
 }
 
@@ -1737,11 +1736,11 @@ double ConformalTracking::checkReal(KDTrack* track, std::map<KDCluster*, MCParti
 
   // Calculate the purity
   double purity = bestHits / nHits;
-  streamlog_out(DEBUG) << "Number of hits on track: " << nHits << ". Good hits: " << bestHits << ". Purity: " << purity
-                       << ". Pt: " << sqrt(bestParticle->getMomentum()[0] * bestParticle->getMomentum()[0] +
-                                           bestParticle->getMomentum()[1] * bestParticle->getMomentum()[1])
-                       << ". Track chi2/ndof: " << track->chi2ndof() << ". Chi2/ndof in SZ fit: " << track->chi2ndofZS()
-                       << std::endl;
+  streamlog_out(DEBUG7) << "Number of hits on track: " << nHits << ". Good hits: " << bestHits << ". Purity: " << purity
+                        << ". Pt: " << sqrt(bestParticle->getMomentum()[0] * bestParticle->getMomentum()[0] +
+                                            bestParticle->getMomentum()[1] * bestParticle->getMomentum()[1])
+                        << ". Track chi2/ndof: " << track->chi2ndof() << ". Chi2/ndof in SZ fit: " << track->chi2ndofZS()
+                        << std::endl;
 
   // Check the track pt estimate
   TLorentzVector mc_helper;
@@ -1755,14 +1754,14 @@ double ConformalTracking::checkReal(KDTrack* track, std::map<KDCluster*, MCParti
   std::vector<KDCluster*> mcHits     = MCparticleHits[bestParticle];
   int                     uniqueHits = getUniqueHits(mcHits);
 
-  streamlog_out(DEBUG) << "Track should contain " << uniqueHits << " hits, "
-                       << ((uniqueHits > bestHits) ? "is missing hits" : "all hits found.") << std::endl;
+  streamlog_out(DEBUG7) << "Track should contain " << uniqueHits << " hits, "
+                        << ((uniqueHits > bestHits) ? "is missing hits" : "all hits found.") << std::endl;
 
   std::vector<KDCluster*> trackHits = track->m_clusters;
   for (int th = 0; th < trackHits.size(); th++) {
-    streamlog_out(DEBUG) << "Hit " << th << " u = " << trackHits[th]->getU() << " v = " << trackHits[th]->getV()
-                         << " x = " << trackHits[th]->getX() << " y = " << trackHits[th]->getY()
-                         << " z = " << trackHits[th]->getZ() << std::endl;
+    streamlog_out(DEBUG7) << "Hit " << th << " u = " << trackHits[th]->getU() << " v = " << trackHits[th]->getV()
+                          << " x = " << trackHits[th]->getX() << " y = " << trackHits[th]->getY()
+                          << " z = " << trackHits[th]->getZ() << std::endl;
 
     // Check which particle the hit belongs to
     MCParticle* particle  = kdParticles[trackHits[th]];
@@ -1770,18 +1769,18 @@ double ConformalTracking::checkReal(KDTrack* track, std::map<KDCluster*, MCParti
     double      mcVertexY = particle->getVertex()[1];
     double      mcVertexR = sqrt(pow(mcVertexX, 2) + pow(mcVertexY, 2));
 
-    streamlog_out(DEBUG) << "Come from particle with id " << particle->getPDG() << " produced at vertexR = " << mcVertexR;
+    streamlog_out(DEBUG7) << "Come from particle with id " << particle->getPDG() << " produced at vertexR = " << mcVertexR;
 
     if (particle->getParents().size() != 0) {
-      streamlog_out(DEBUG) << ". Comes from particle with id " << particle->getParents()[0]->getPDG();
+      streamlog_out(DEBUG7) << ". Comes from particle with id " << particle->getParents()[0]->getPDG();
     }
-    streamlog_out(DEBUG) << std::endl;
+    streamlog_out(DEBUG7) << std::endl;
   }
 
-  //  for(int itCluster=0;itCluster<clusters.size();itCluster++)streamlog_out(DEBUG)<<"Hit "<<itCluster<<" has position: "<<clusters[itCluster]->getU()<<","<<clusters[itCluster]->getV()<<std::endl;
-  streamlog_out(DEBUG) << "== Terms in conformal fit: " << track->m_intercept << ", " << track->m_gradient << ", "
-                       << track->m_quadratic << std::endl;
-  streamlog_out(DEBUG) << "== Terms in zs fit: " << track->m_interceptZS << ", " << track->m_gradientZS << std::endl;
+  //  for(int itCluster=0;itCluster<clusters.size();itCluster++)streamlog_out(DEBUG7)<<"Hit "<<itCluster<<" has position: "<<clusters[itCluster]->getU()<<","<<clusters[itCluster]->getV()<<std::endl;
+  streamlog_out(DEBUG7) << "== Terms in conformal fit: " << track->m_intercept << ", " << track->m_gradient << ", "
+                        << track->m_quadratic << std::endl;
+  streamlog_out(DEBUG7) << "== Terms in zs fit: " << track->m_interceptZS << ", " << track->m_gradientZS << std::endl;
 
   track->linearRegressionConformal(true);
   track->calculateChi2SZ(NULL, true);
@@ -1829,44 +1828,44 @@ void ConformalTracking::checkReconstructionFailure(MCParticle* particle,
 
   // Sort the hits from larger to smaller radius
   std::sort(trackHits.begin(), trackHits.end(), sort_by_radiusKD);
-  streamlog_out(DEBUG) << "Track contains " << getUniqueHits(trackHits) << " unique hits. Track size is " << trackHits.size()
-                       << std::endl;
+  streamlog_out(DEBUG7) << "Track contains " << getUniqueHits(trackHits) << " unique hits. Track size is "
+                        << trackHits.size() << std::endl;
 
   for (int th = 0; th < trackHits.size(); th++)
-    streamlog_out(DEBUG) << "Hit " << th << " u = " << trackHits[th]->getU() << " v = " << trackHits[th]->getV()
-                         << " x = " << trackHits[th]->getX() << " y = " << trackHits[th]->getY()
-                         << " z = " << trackHits[th]->getZ() << ". " << (trackHits[th]->used() ? "Used!" : "") << std::endl;
+    streamlog_out(DEBUG7) << "Hit " << th << " u = " << trackHits[th]->getU() << " v = " << trackHits[th]->getV()
+                          << " x = " << trackHits[th]->getX() << " y = " << trackHits[th]->getY()
+                          << " z = " << trackHits[th]->getZ() << ". " << (trackHits[th]->used() ? "Used!" : "") << std::endl;
 
   // Take the seed hit and build cell to 2nd
   KDCluster* seedHit = trackHits[0];
   VecCluster results;
-  streamlog_out(DEBUG) << "- getting nearest neighbours for seed" << std::endl;
+  streamlog_out(DEBUG7) << "- getting nearest neighbours for seed" << std::endl;
   //  nearestNeighbours->allNeighboursInRadius(seedHit, m_maxDistance, results);
   double theta = seedHit->getTheta();
   nearestNeighbours->allNeighboursInTheta(theta, m_thetaRange, results);
-  streamlog_out(DEBUG) << "- got nearest neighbours for seed" << std::endl;
+  streamlog_out(DEBUG7) << "- got nearest neighbours for seed" << std::endl;
 
   // If we don't produce the seed cell we have failed
   if (std::find(results.begin(), results.end(), trackHits[1]) == results.end()) {
-    streamlog_out(DEBUG) << "- seed cell not produced, neighbour not inside search window" << std::endl;
+    streamlog_out(DEBUG7) << "- seed cell not produced, neighbour not inside search window" << std::endl;
     double deltaU = fabs(trackHits[1]->getU() - trackHits[0]->getU());
     double deltaV = fabs(trackHits[1]->getV() - trackHits[0]->getV());
-    streamlog_out(DEBUG) << "- distance between hits is " << sqrt(deltaU * deltaU + deltaV * deltaV)
-                         << " and search distance is " << m_maxDistance << std::endl;
-    streamlog_out(DEBUG) << "- theta of hits is " << trackHits[0]->getTheta() << " and " << trackHits[1]->getTheta()
-                         << ", delta theta = " << trackHits[0]->getTheta() - trackHits[1]->getTheta() << std::endl;
+    streamlog_out(DEBUG7) << "- distance between hits is " << sqrt(deltaU * deltaU + deltaV * deltaV)
+                          << " and search distance is " << m_maxDistance << std::endl;
+    streamlog_out(DEBUG7) << "- theta of hits is " << trackHits[0]->getTheta() << " and " << trackHits[1]->getTheta()
+                          << ", delta theta = " << trackHits[0]->getTheta() - trackHits[1]->getTheta() << std::endl;
     //    return;
   }
 
   if (trackHits[1]->getR() >= trackHits[0]->getR()) {
-    streamlog_out(DEBUG) << "- seed cell not produced, neighbour at higher radius" << std::endl;
+    streamlog_out(DEBUG7) << "- seed cell not produced, neighbour at higher radius" << std::endl;
     //    return;
   }
 
   double length = sqrt((trackHits[1]->getU() - trackHits[0]->getU()) * (trackHits[1]->getU() - trackHits[0]->getU()) +
                        (trackHits[1]->getV() - trackHits[0]->getV()) * (trackHits[1]->getV() - trackHits[0]->getV()));
   if (length > m_maxDistance) {
-    streamlog_out(DEBUG) << "- seed cell not produced, neighbour too far away" << std::endl;
+    streamlog_out(DEBUG7) << "- seed cell not produced, neighbour too far away" << std::endl;
     //    return;
   }
 
@@ -1874,7 +1873,7 @@ void ConformalTracking::checkReconstructionFailure(MCParticle* particle,
   Cell*              seedCell = new Cell(trackHits[0], trackHits[1]);
   std::vector<Cell*> cells;
   cells.push_back(seedCell);
-  streamlog_out(DEBUG) << "have seed cell" << std::endl;
+  streamlog_out(DEBUG7) << "have seed cell" << std::endl;
   // CHECK CELL LENGTH!! TO DO
 
   int  hitNumber     = 1;  // Current hit after the seed cell has been formed
@@ -1892,33 +1891,33 @@ void ConformalTracking::checkReconstructionFailure(MCParticle* particle,
 
     // Check if we found the hit we wanted
     if (std::find(results2.begin(), results2.end(), trackHits[hitNumber + 1]) == results2.end()) {
-      streamlog_out(DEBUG) << "- could not find hit number " << hitNumber + 1 << " inside the search window" << std::endl;
+      streamlog_out(DEBUG7) << "- could not find hit number " << hitNumber + 1 << " inside the search window" << std::endl;
       double deltaU = fabs(trackHits[hitNumber + 1]->getU() - trackHits[hitNumber]->getU());
       double deltaV = fabs(trackHits[hitNumber + 1]->getV() - trackHits[hitNumber]->getV());
-      streamlog_out(DEBUG) << "- distance between hits is " << sqrt(deltaU * deltaU + deltaV * deltaV)
-                           << " and search distance is " << m_maxDistance << std::endl;
+      streamlog_out(DEBUG7) << "- distance between hits is " << sqrt(deltaU * deltaU + deltaV * deltaV)
+                            << " and search distance is " << m_maxDistance << std::endl;
       //      for(int c=0;c<cells.size();c++) delete cells[c];
       //      return;
     }
 
     // Check radial conditions
     if (trackHits[hitNumber + 1]->getR() >= trackHits[hitNumber]->getR()) {
-      streamlog_out(DEBUG) << "- cell " << hitNumber << " not produced, neighbour at higher radius" << std::endl;
+      streamlog_out(DEBUG7) << "- cell " << hitNumber << " not produced, neighbour at higher radius" << std::endl;
       //      return;
     }
 
     // Make the cell for extrapolation in the next round
     Cell* cell = new Cell(trackHits[hitNumber], trackHits[hitNumber + 1]);
-    streamlog_out(DEBUG) << "have new cell" << std::endl;
+    streamlog_out(DEBUG7) << "have new cell" << std::endl;
 
     // Check if the cell would be killed by cuts
     if (cells.back()->getAngle(cell) > m_maxCellAngle || cells.back()->getAngleRZ(cell) > m_maxCellAngleRZ) {
       if (cells.back()->getAngle(cell) > m_maxCellAngle)
-        streamlog_out(DEBUG) << "- cell " << hitNumber << " killed by angular cut. Angle is " << cells.back()->getAngle(cell)
-                             << std::endl;
+        streamlog_out(DEBUG7) << "- cell " << hitNumber << " killed by angular cut. Angle is "
+                              << cells.back()->getAngle(cell) << std::endl;
       if (cells.back()->getAngleRZ(cell) > m_maxCellAngleRZ)
-        streamlog_out(DEBUG) << "- cell " << hitNumber << " killed by RZ angular cut. Angle is "
-                             << cells.back()->getAngleRZ(cell) << std::endl;
+        streamlog_out(DEBUG7) << "- cell " << hitNumber << " killed by RZ angular cut. Angle is "
+                              << cells.back()->getAngleRZ(cell) << std::endl;
       //      for(int c=0;c<cells.size();c++) delete cells[c];
       //      return;
     }
@@ -1940,8 +1939,8 @@ void ConformalTracking::checkReconstructionFailure(MCParticle* particle,
   createTracksNew(cellularTracks, cells.back(), usedCells);
 
   if (cellularTracks.size() != 1) {
-    streamlog_out(DEBUG) << "- cellular track not produced from cells. Returned " << cellularTracks.size() << " candidates"
-                         << std::endl;
+    streamlog_out(DEBUG7) << "- cellular track not produced from cells. Returned " << cellularTracks.size() << " candidates"
+                          << std::endl;
     for (int c = 0; c < cells.size(); c++)
       delete cells[c];
     for (int ct = 0; ct < cellularTracks.size(); ct++)
@@ -1951,9 +1950,9 @@ void ConformalTracking::checkReconstructionFailure(MCParticle* particle,
 
   // Check that all of the hits are on the track
   if (cellularTracks[0]->size() != (trackHits.size() - 1)) {
-    streamlog_out(DEBUG) << "- failed to put all cells on track. Cellular track size: " << cellularTracks[0]->size()
-                         << std::endl;
-    streamlog_out(DEBUG) << "- number of cells held: " << cells.size() << std::endl;
+    streamlog_out(DEBUG7) << "- failed to put all cells on track. Cellular track size: " << cellularTracks[0]->size()
+                          << std::endl;
+    streamlog_out(DEBUG7) << "- number of cells held: " << cells.size() << std::endl;
     return;
   }
 
@@ -1962,8 +1961,8 @@ void ConformalTracking::checkReconstructionFailure(MCParticle* particle,
   getFittedTracks(finalTracks, cellularTracks, usedCells);
 
   if (finalTracks.size() != 1) {
-    streamlog_out(DEBUG) << "- kd track not produced from cellular track. Returned " << finalTracks.size() << " candidates"
-                         << std::endl;
+    streamlog_out(DEBUG7) << "- kd track not produced from cellular track. Returned " << finalTracks.size() << " candidates"
+                          << std::endl;
     for (int c = 0; c < cells.size(); c++)
       delete cells[c];
     for (int t = 0; t < finalTracks.size(); t++)
@@ -1975,19 +1974,19 @@ void ConformalTracking::checkReconstructionFailure(MCParticle* particle,
   KDTrack* mcTrack = finalTracks[0];
   mcTrack->linearRegressionConformal(true);
 
-  streamlog_out(DEBUG) << "== Track chi2/ndof is " << mcTrack->chi2ndof() << ", ZS chi2/ndof is " << mcTrack->chi2ndofZS()
-                       << std::endl;
-  streamlog_out(DEBUG) << "== Terms in conformal fit: " << mcTrack->m_intercept << ", " << mcTrack->m_gradient << ", "
-                       << mcTrack->m_quadratic << std::endl;
-  streamlog_out(DEBUG) << "== Terms in zs fit: " << mcTrack->m_interceptZS << ", " << mcTrack->m_gradientZS << std::endl;
+  streamlog_out(DEBUG7) << "== Track chi2/ndof is " << mcTrack->chi2ndof() << ", ZS chi2/ndof is " << mcTrack->chi2ndofZS()
+                        << std::endl;
+  streamlog_out(DEBUG7) << "== Terms in conformal fit: " << mcTrack->m_intercept << ", " << mcTrack->m_gradient << ", "
+                        << mcTrack->m_quadratic << std::endl;
+  streamlog_out(DEBUG7) << "== Terms in zs fit: " << mcTrack->m_interceptZS << ", " << mcTrack->m_gradientZS << std::endl;
   mcTrack->calculateChi2SZ(NULL, true);
 
   if (mcTrack->chi2ndof() > m_chi2cut || mcTrack->chi2ndofZS() > m_chi2cut) {
     if (mcTrack->chi2ndof() > m_chi2cut)
-      streamlog_out(DEBUG) << "- track killed by chi2/ndof cut. Track chi2/ndof is " << mcTrack->chi2ndof() << std::endl;
+      streamlog_out(DEBUG7) << "- track killed by chi2/ndof cut. Track chi2/ndof is " << mcTrack->chi2ndof() << std::endl;
     if (mcTrack->chi2ndofZS() > m_chi2cut)
-      streamlog_out(DEBUG) << "- track killed by ZS chi2/ndof cut. Track chi2/ndof in ZS is " << mcTrack->chi2ndofZS()
-                           << std::endl;
+      streamlog_out(DEBUG7) << "- track killed by ZS chi2/ndof cut. Track chi2/ndof in ZS is " << mcTrack->chi2ndofZS()
+                            << std::endl;
     for (int c = 0; c < cells.size(); c++)
       delete cells[c];
     for (int t = 0; t < finalTracks.size(); t++)
@@ -1995,7 +1994,7 @@ void ConformalTracking::checkReconstructionFailure(MCParticle* particle,
     return;
   }
 
-  streamlog_out(DEBUG) << "== Should have produced this track" << std::endl;
+  streamlog_out(DEBUG7) << "== Should have produced this track" << std::endl;
   for (int c = 0; c < cells.size(); c++)
     delete cells[c];
   for (int t = 0; t < finalTracks.size(); t++)


### PR DESCRIPTION
BEGINRELEASENOTES
- Added clang-format to cmake lists and added extra target. "make format" will now format the code, and will be prepared automatically if clang-format exists.
- Updated tracking strategy and added some improvements in terms of refitting tracks each time a hit is added, and included a maximum chi2 criteria for adding hits

ENDRELEASENOTES