### PR TITLE
Remove include of removed file

### DIFF
--- a/src/ConformalTracking.cc
+++ b/src/ConformalTracking.cc
@@ -1,5 +1,4 @@
 #include "ConformalTracking.h"
-#include "DDRec/API/IDDecoder.h"
 
 #include "MarlinTrk/Factory.h"
 #include "MarlinTrk/HelixFit.h"


### PR DESCRIPTION
BEGINRELEASENOTES
- Drop unused and no longer existing header includes AidaSoft/DD4hep#241

ENDRELEASENOTES
