### PR TITLE
make compatibel for other detectors, e.g. ILD

### DIFF
--- a/include/ConformalTracking.h
+++ b/include/ConformalTracking.h
@@ -133,8 +133,8 @@ protected:
   std::string              m_inputParticleCollection{};
   std::vector<std::string> m_inputRelationCollections{};
   std::string              m_outputDebugHits{};
-  std::vector<int>         m_allHits ;
-  std::vector<int>         m_trackerHits ;
+  std::vector<int>         m_allHits{};
+  std::vector<int>         m_trackerHits{};
 
   // Run and event counters
   int m_eventNumber = 0;

--- a/include/ConformalTracking.h
+++ b/include/ConformalTracking.h
@@ -133,6 +133,8 @@ protected:
   std::string              m_inputParticleCollection{};
   std::vector<std::string> m_inputRelationCollections{};
   std::string              m_outputDebugHits{};
+  std::vector<int>         m_allHits ;
+  std::vector<int>         m_trackerHits ;
 
   // Run and event counters
   int m_eventNumber = 0;


### PR DESCRIPTION
BEGINRELEASENOTES
- make compatible for other detectors, e.g. ILD
     - introduce new parameters with indices of tracker hit collections:
          - AllHitCollectionIndices
          - TrackerHitCollectionIndices
      - default values as used for CLIC
      - protect against empty collections


ENDRELEASENOTES