### PR TITLE
ConformalTracking: [extendTracks]fix for hits from the same subdetect…

### DIFF
--- a/src/ConformalTracking.cc
+++ b/src/ConformalTracking.cc
@@ -1387,9 +1387,7 @@ void ConformalTracking::extendTracks(UniqueKDTracks& conformalTracks, SharedKDCl
         continue;
 
       bool onSameLayer = false;
-
-      for (unsigned int hitOnTrack = 0; hitOnTrack < conformalTracks[currentTrack]->m_clusters.size(); hitOnTrack++) {
-        SKDCluster const& clusterOnTrack = conformalTracks[currentTrack]->m_clusters.at(hitOnTrack);
+      for (auto const& clusterOnTrack : conformalTracks[currentTrack]->m_clusters) {
         if (kdhit->sameLayer(clusterOnTrack)) {
           onSameLayer = true;
           break;

--- a/src/ConformalTracking.cc
+++ b/src/ConformalTracking.cc
@@ -1386,6 +1386,18 @@ void ConformalTracking::extendTracks(UniqueKDTracks& conformalTracks, SharedKDCl
       if (deltaChi2 > chi2cut || deltaChi2zs > chi2cut)
         continue;
 
+      bool onSameLayer = false;
+
+      for (unsigned int hitOnTrack = 0; hitOnTrack < conformalTracks[currentTrack]->m_clusters.size(); hitOnTrack++) {
+        SKDCluster clusterOnTrack = conformalTracks[currentTrack]->m_clusters.at(hitOnTrack);
+        if (kdhit->sameLayer(clusterOnTrack)) {
+          onSameLayer = true;
+          break;
+        }
+      }
+      if (onSameLayer)
+        continue;
+
       if (associated)
         streamlog_out(DEBUG7) << "-- valid candidate!" << std::endl;
 

--- a/src/ConformalTracking.cc
+++ b/src/ConformalTracking.cc
@@ -1389,7 +1389,7 @@ void ConformalTracking::extendTracks(UniqueKDTracks& conformalTracks, SharedKDCl
       bool onSameLayer = false;
 
       for (unsigned int hitOnTrack = 0; hitOnTrack < conformalTracks[currentTrack]->m_clusters.size(); hitOnTrack++) {
-        SKDCluster clusterOnTrack = conformalTracks[currentTrack]->m_clusters.at(hitOnTrack);
+        SKDCluster const& clusterOnTrack = conformalTracks[currentTrack]->m_clusters.at(hitOnTrack);
         if (kdhit->sameLayer(clusterOnTrack)) {
           onSameLayer = true;
           break;


### PR DESCRIPTION
…or layer not to be accepted in the same track



BEGINRELEASENOTES
- ConformalTracking.cc: [extendTracks]fix for hits from the same subdetector layers not to be accepted in the same track, when tracks are extended to vertex endcap and to trackers

ENDRELEASENOTES

- ConformalTracking.cc: tracks are extended with the function extendTracks(). This is called twice: (1) for extending in the vertex endcap tracks built in the vertex barrel, (2) for extending in the trackers (inner+outer) tracks built in the vertex (barrel+endcap)
- extendTracks() works in two phases: first, tracks are extended with the function extendHighPt() which uses tighter cuts in terms of cell angle for nearest neighbors search; then a further loop over all hits in the tracker collections allow for recovering hits that were not added in the first phase
- a check on whether the hits belonged to the same subdetector layer was performed only among the set of hits added in the second phase. There was no such check with the hits that were already on track (added to the track in the first extension phase)
- this commit fixes this problem