### PR TITLE
ConformalTracking: looser cuts all at once (angles and chi2), keep ch…

### DIFF
--- a/src/ConformalTracking.cc
+++ b/src/ConformalTracking.cc
@@ -580,6 +580,7 @@ void ConformalTracking::processEvent(LCEvent* evt) {
 
   lowerCellAngleParameters._maxCellAngle *= 2.;
   lowerCellAngleParameters._maxCellAngleRZ *= 2.;
+  lowerCellAngleParameters._chi2cut *= 20.;
 
   buildNewTracks(conformalTracks, kdClusters, nearestNeighbours, lowerCellAngleParameters, true);
   // Mark hits from "good" tracks as being used
@@ -617,7 +618,7 @@ void ConformalTracking::processEvent(LCEvent* evt) {
 
   //m_highPTfit = false;
 
-  lowNumberHitsParameters._chi2cut = m_chi2cut;
+  //lowNumberHitsParameters._chi2cut = m_chi2cut;
 
   // Extend them through the inner and outer trackers
   stopwatch->Start(false);
@@ -1206,26 +1207,15 @@ void ConformalTracking::buildNewTracks(UniqueKDTracks& conformalTracks, SharedKD
           else if (nOverlappingHits == bestTrack->m_clusters.size())
             break;
 
-          // Otherwise take the longest if the delta chi2 is not too much
+          // Otherwise take the longest
           else if (bestTrack->m_clusters.size() >= conformalTrack->m_clusters.size()) {  // New track longer/equal in length
 
-            // Increase in chi2 is too much (double)
-            if ((newchi2 - oldchi2) > oldchi2)
-              break;
-
-            // Otherwise take it
+            // Take it
             conformalTrack = std::move(bestTrack);
             bestTrackUsed  = true;
-          } else if (bestTrack->m_clusters.size() < conformalTrack->m_clusters.size()) {  // Old track longer
 
-            // Must improve chi2 by factor two
-            if ((newchi2 - 0.5 * oldchi2) > 0.)
-              break;
-
-            // Otherwise take it
-            conformalTrack = std::move(bestTrack);
-            bestTrackUsed  = true;
-          }
+          } else if (bestTrack->m_clusters.size() < conformalTrack->m_clusters.size())  // Old track longer
+            break;
 
           break;
         }


### PR DESCRIPTION
…i2 open for extendTracks and when clones, prefer the longest



BEGINRELEASENOTES
- ConformalTracking: fixed two issues, one in the pattern recognition, one in the choice among clones
- when building tracks in the combined vertex barrel + endcap, the step with looser cut must be done all at one (open the angles and increase the chi2 cut at the same time, not in two subsequent steps), otherwise tracks are made with less hits than desired
- once increased, keep the chi2 cut the same for subsequent steps
- in presence of clones, it is not good to prefer shorter tracks with better chi2 (the comparison is also progressive, so one can easily go from a 8 hits track to a 4 hits track). To avoid in order not to have double tracks per particle

ENDRELEASENOTES