### PR TITLE
ConformalTracking: restructured with runStep

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,12 @@ env:
 
 
 before_install:
-  - wget https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
+  - wget --no-check-certificate https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest_all.deb
   - sudo dpkg -i cvmfs-release-latest_all.deb
   - sudo apt-get update
   - sudo apt-get install cvmfs cvmfs-config-default
   - rm -f cvmfs-release-latest_all.deb
-  - wget https://lcd-data.web.cern.ch/lcd-data/CernVM/default.local
+  - wget --no-check-certificate https://lcd-data.web.cern.ch/lcd-data/CernVM/default.local
   - sudo mkdir -p /etc/cvmfs
   - sudo mv default.local /etc/cvmfs/default.local
   - sudo /etc/init.d/autofs stop
@@ -38,7 +38,7 @@ install:
   - export description=`date`
   - export COVERITY_REPO=`echo ${TRAVIS_REPO_SLUG} | sed 's/\//\%2F/g'`
   - if [[ "${TRAVIS_EVENT_TYPE}" == "cron" && "${COMPILER}" == "gcc"  ]];
-    then wget https://scan.coverity.com/download/linux64 --post-data "token=${COVERITY_SCAN_TOKEN}&project=${COVERITY_REPO}" -O Package/coverity_tool.tgz; cd Package; mkdir cov-analysis-linux64; tar -xf coverity_tool.tgz -C cov-analysis-linux64 --strip-components=2;
+    then wget --no-check-certificate https://scan.coverity.com/download/linux64 --post-data "token=${COVERITY_SCAN_TOKEN}&project=${COVERITY_REPO}" -O Package/coverity_tool.tgz; cd Package; mkdir cov-analysis-linux64; tar -xf coverity_tool.tgz -C cov-analysis-linux64 --strip-components=2;
     fi
 
 # command to run tests


### PR DESCRIPTION

BEGINRELEASENOTES
- Conformal Tracking restructured to be run in steps with function runStep
- runStep allows to decide which functions to run per step for the reconstruction, i.e. combineCollections, buildNewTracks, extendTracks
- prior to runStep, the set of parameters for the reconstruction step is initialized
ENDRELEASENOTES