### PR TITLE
ConformalTrackingV2: removed init()

### DIFF
--- a/include/ConformalTrackingV2.h
+++ b/include/ConformalTrackingV2.h
@@ -11,9 +11,6 @@ public:
   ConformalTrackingV2(const ConformalTrackingV2&) = delete;
   ConformalTrackingV2& operator=(const ConformalTrackingV2&) = delete;
 
-  // Initialisation - run at the beginning to start histograms, etc.
-  virtual void init();
-
   // Called at the beginning of every run
   virtual void processRunHeader(LCRunHeader*) { m_runNumber++; }
 

--- a/src/ConformalTrackingV2.cc
+++ b/src/ConformalTrackingV2.cc
@@ -52,12 +52,6 @@ ConformalTrackingV2::ConformalTrackingV2() : ConformalTracking("ConformalTrackin
   registerProcessorParameter("ThetaRange", "Angular range for initial cell seeding", m_thetaRange, double(0.1));
 }
 
-void ConformalTrackingV2::init() {
-  ConformalTracking::init();
-
-  parseStepParameters();
-}
-
 void ConformalTrackingV2::parseStepParameters() {
   ParameterParser::parseParameters(_stepParameters, m_rawSteps, m_inputTrackerHitCollections);
 }  //parseStepParameters


### PR DESCRIPTION
BEGINRELEASENOTES
- ConformalTrackingV2: removed the call to init()
  - init() is already done in ConformalTracking.cc
  - since in init() the step parameters are parsed, they were parsed twice, resulting in twice the number of steps in the pattern recognition chain
ENDRELEASENOTES