### PR TITLE
Set pt threshold to run extendHighPt as external parameter

### DIFF
--- a/include/ConformalTracking.h
+++ b/include/ConformalTracking.h
@@ -189,6 +189,7 @@ protected:
   double            m_maxCellAngle       = 0.0;
   double            m_maxCellAngleRZ     = 0.0;
   double            m_maxDistance        = 0.0;
+  double            m_highPTcut          = 0.0;
   int               m_minClustersOnTrack = 0;
   bool              m_enableTCVC         = true;
   bool              m_debugPlots         = false;

--- a/include/ConformalTrackingV2.h
+++ b/include/ConformalTrackingV2.h
@@ -21,32 +21,32 @@ protected:
   std::vector<std::string> m_rawSteps = {R"RAW(
     [VXDBarrel]
     @Collections : VXDTrackerHits
-    @Parameters : MaxCellAngle : 0.005; MaxCellAngleRZ : 0.005; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.02;
+    @Parameters : MaxCellAngle : 0.005; MaxCellAngleRZ : 0.005; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.02; HighPTCut : 10.0;
     @Flags : HighPTFit, VertexToTracker
     @Functions : CombineCollections, BuildNewTracks
     [VXDEncap]
     @Collections : VXDEndcapTrackerHits
-    @Parameters : MaxCellAngle : 0.005; MaxCellAngleRZ : 0.005; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.02;
+    @Parameters : MaxCellAngle : 0.005; MaxCellAngleRZ : 0.005; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.02; HighPTCut : 10.0;
     @Flags : HighPTFit, VertexToTracker
     @Functions : CombineCollections, ExtendTracks
     [LowerCellAngle1]
     @Collections : VXDTrackerHits, VXDEndcapTrackerHits
-    @Parameters : MaxCellAngle : 0.025; MaxCellAngleRZ : 0.025; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.02;
+    @Parameters : MaxCellAngle : 0.025; MaxCellAngleRZ : 0.025; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.02; HighPTCut : 10.0;
     @Flags : HighPTFit, VertexToTracker, RadialSearch
     @Functions : CombineCollections, BuildNewTracks
     [LowerCellAngle2]
     @Collections :
-    @Parameters : MaxCellAngle : 0.05; MaxCellAngleRZ : 0.05; Chi2Cut : 2000; MinClustersOnTrack : 4; MaxDistance : 0.02;
+    @Parameters : MaxCellAngle : 0.05; MaxCellAngleRZ : 0.05; Chi2Cut : 2000; MinClustersOnTrack : 4; MaxDistance : 0.02; HighPTCut : 10.0;
     @Flags : HighPTFit, VertexToTracker, RadialSearch
     @Functions : BuildNewTracks, SortTracks
     [Tracker]
     @Collections : ITrackerHits, OTrackerHits, ITrackerEndcapHits, OTrackerEndcapHits
-    @Parameters : MaxCellAngle : 0.05; MaxCellAngleRZ : 0.05; Chi2Cut : 2000; MinClustersOnTrack : 4; MaxDistance : 0.02;
+    @Parameters : MaxCellAngle : 0.05; MaxCellAngleRZ : 0.05; Chi2Cut : 2000; MinClustersOnTrack : 4; MaxDistance : 0.02; HighPTCut : 1.0;
     @Flags : HighPTFit, VertexToTracker, RadialSearch
     @Functions : CombineCollections, ExtendTracks
     [Displaced]
     @Collections : VXDTrackerHits, VXDEndcapTrackerHits, ITrackerHits, OTrackerHits, ITrackerEndcapHits, OTrackerEndcapHits
-    @Parameters : MaxCellAngle : 0.05; MaxCellAngleRZ : 0.05; Chi2Cut : 1000; MinClustersOnTrack : 5; MaxDistance : 0.015;
+    @Parameters : MaxCellAngle : 0.05; MaxCellAngleRZ : 0.05; Chi2Cut : 1000; MinClustersOnTrack : 5; MaxDistance : 0.015; HighPTCut : 10.0;
     @Flags : OnlyZSchi2cut, RadialSearch
     @Functions : CombineCollections, BuildNewTracks
 )RAW"

--- a/include/Parameters.h
+++ b/include/Parameters.h
@@ -20,6 +20,7 @@ public:
   double           _chi2cut;
   int              _minClustersOnTrack;
   double           _maxDistance;
+  double           _highPTcut;
   bool             _highPTfit;
   bool             _onlyZSchi2cut;
   bool             _radialSearch;
@@ -38,18 +39,19 @@ public:
       "HighPTFit", "OnlyZSchi2cut", "RadialSearch", "VertexToTracker",
   };
   const StringVec _existingParameters = {
-      "MaxCellAngle", "MaxCellAngleRZ", "Chi2Cut", "MinClustersOnTrack", "MaxDistance",
+      "MaxCellAngle", "MaxCellAngleRZ", "Chi2Cut", "MinClustersOnTrack", "MaxDistance", "HighPTCut",
   };
 
   Parameters(std::vector<int> const& collections, double maxCellAngle, double maxCellAngleRZ, double chi2cut,
-             int minClustersOnTrack, double maxDistance, bool highPTfit, bool onlyZSchi2cut, bool radialSearch,
-             bool vertexToTracker, int step, bool combine, bool build, bool extend, bool sortTracks)
+             int minClustersOnTrack, double maxDistance, double highPTcut, bool highPTfit, bool onlyZSchi2cut,
+             bool radialSearch, bool vertexToTracker, int step, bool combine, bool build, bool extend, bool sortTracks)
       : _collections(collections),
         _maxCellAngle(maxCellAngle),
         _maxCellAngleRZ(maxCellAngleRZ),
         _chi2cut(chi2cut),
         _minClustersOnTrack(minClustersOnTrack),
         _maxDistance(maxDistance),
+        _highPTcut(highPTcut),
         _highPTfit(highPTfit),
         _onlyZSchi2cut(onlyZSchi2cut),
         _radialSearch(radialSearch),

--- a/src/Parameters.cc
+++ b/src/Parameters.cc
@@ -14,6 +14,7 @@ Parameters::Parameters(ParameterParser::ParsedParameters const& ps, std::vector<
       _chi2cut(ps._parameters.at("Chi2Cut")),
       _minClustersOnTrack(ps._parameters.at("MinClustersOnTrack")),
       _maxDistance(ps._parameters.at("MaxDistance")),
+      _highPTcut(ps._parameters.at("HighPTCut")),
       _highPTfit(findEntry(ps._flags, "HighPTFit")),
       _onlyZSchi2cut(findEntry(ps._flags, "OnlyZSchi2cut")),
       _radialSearch(findEntry(ps._flags, "RadialSearch")),


### PR DESCRIPTION
BEGINRELEASENOTES
- The pt threshold to run extendHighPt is now a parameter, to be set in the steering file
  - It has effect only on the steps when extendTracks is run (buildNewTracks does not use extendHighPt)
  - Default values at the moment: 10 GeV for extending in the vertex endcap, 1 GeV for extending in the trackers 
ENDRELEASENOTES