### PR TITLE
Implemented kalman fit direction (forward/backward) as parsed flags. Parameters added as member o…

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,33 +27,33 @@ file. The parameter *Steps* takes a "Config" like String.  For example:
 
     [VXDBarrel]
     @Collections : VXDTrackerHits
-    @Parameters : MaxCellAngle : 0.005; MaxCellAngleRZ : 0.005; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.02;
-    @Flags : HighPTFit, VertexToTracker
+    @Parameters : MaxCellAngle : 0.005; MaxCellAngleRZ : 0.005; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.02; HighPTCut: 10.0;
+    @Flags : HighPTFit, VertexToTracker, KalmanFitForward
     @Functions : CombineCollections, BuildNewTracks
     [VXDEncap]
     @Collections : VXDEndcapTrackerHits
-    @Parameters : MaxCellAngle : 0.005; MaxCellAngleRZ : 0.005; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.02;
-    @Flags : HighPTFit, VertexToTracker
+    @Parameters : MaxCellAngle : 0.005; MaxCellAngleRZ : 0.005; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.02; HighPTCut: 10.0;
+    @Flags : HighPTFit, VertexToTracker, KalmanFitForward
     @Functions : CombineCollections, ExtendTracks
     [LowerCellAngle1]
     @Collections : VXDTrackerHits, VXDEndcapTrackerHits
-    @Parameters : MaxCellAngle : 0.025; MaxCellAngleRZ : 0.025; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.02;
-    @Flags : HighPTFit, VertexToTracker, RadialSearch
+    @Parameters : MaxCellAngle : 0.025; MaxCellAngleRZ : 0.025; Chi2Cut : 100; MinClustersOnTrack : 4; MaxDistance : 0.02; HighPTCut: 10.0;
+    @Flags : HighPTFit, VertexToTracker, RadialSearch, KalmanFitForward
     @Functions : CombineCollections, BuildNewTracks
     [LowerCellAngle2]
     @Collections :
-    @Parameters : MaxCellAngle : 0.05; MaxCellAngleRZ : 0.05; Chi2Cut : 2000; MinClustersOnTrack : 4; MaxDistance : 0.02;
-    @Flags : HighPTFit, VertexToTracker, RadialSearch
+    @Parameters : MaxCellAngle : 0.05; MaxCellAngleRZ : 0.05; Chi2Cut : 2000; MinClustersOnTrack : 4; MaxDistance : 0.02; HighPTCut: 10.0;
+    @Flags : HighPTFit, VertexToTracker, RadialSearch, KalmanFitForward
     @Functions : BuildNewTracks, SortTracks
     [Tracker]
     @Collections : ITrackerHits, OTrackerHits, ITrackerEndcapHits, OTrackerEndcapHits
-    @Parameters : MaxCellAngle : 0.05; MaxCellAngleRZ : 0.05; Chi2Cut : 2000; MinClustersOnTrack : 4; MaxDistance : 0.02;
-    @Flags : HighPTFit, VertexToTracker, RadialSearch
+    @Parameters : MaxCellAngle : 0.05; MaxCellAngleRZ : 0.05; Chi2Cut : 2000; MinClustersOnTrack : 4; MaxDistance : 0.02; HighPTCut: 1.0;
+    @Flags : HighPTFit, VertexToTracker, RadialSearch, KalmanFitForward
     @Functions : CombineCollections, ExtendTracks
     [Displaced]
     @Collections : VXDTrackerHits, VXDEndcapTrackerHits, ITrackerHits, OTrackerHits, ITrackerEndcapHits, OTrackerEndcapHits
-    @Parameters : MaxCellAngle : 0.05; MaxCellAngleRZ : 0.05; Chi2Cut : 1000; MinClustersOnTrack : 5; MaxDistance : 0.015;
-    @Flags : OnlyZSchi2cut, RadialSearch
+    @Parameters : MaxCellAngle : 0.05; MaxCellAngleRZ : 0.05; Chi2Cut : 1000; MinClustersOnTrack : 5; MaxDistance : 0.015; HighPTCut: 10.0;
+    @Flags : OnlyZSchi2cut, RadialSearch, KalmanFitBackward
     @Functions : CombineCollections, BuildNewTracks
 
 Each steps starts with a *[Name]* in brackets. Following are the *@Collections*,
@@ -70,6 +70,7 @@ The *@Parameters* are
   * Chi2Cut
   * MinClustersOnTrack
   * MaxDistance
+  * HighPTCut
 
 Possible *@Flags* are
 
@@ -77,6 +78,8 @@ Possible *@Flags* are
   * VertexToTracker
   * RadialSearch
   * HighPTFit
+  * KalmanFitForward
+  * KalmanFitBackward
 
 Possible *@Functions* are
 

--- a/include/KDTrack.h
+++ b/include/KDTrack.h
@@ -2,6 +2,7 @@
 #define KDTRACK_H 1
 
 #include "KDCluster.h"
+#include "Parameters.h"
 
 #include <cmath>
 
@@ -18,7 +19,7 @@ class KalmanTrack;
 class KDTrack {
 public:
   //--- Constructor and destructor
-  KDTrack();
+  KDTrack(Parameters const& par);
   ~KDTrack();
 
   KDTrack(const KDTrack&) = default;
@@ -95,7 +96,8 @@ public:
   int              m_nPoints = 0;
   double           m_pT      = 0.0;
   SharedKDClusters m_clusters{};
-  KalmanTrack*     m_kalmanTrack = nullptr;
+  KalmanTrack*     m_kalmanTrack      = nullptr;
+  bool             m_kalmanFitForward = true;
 
 private:
 };

--- a/include/Parameters.h
+++ b/include/Parameters.h
@@ -25,6 +25,7 @@ public:
   bool             _onlyZSchi2cut;
   bool             _radialSearch;
   bool             _vertexToTracker;
+  bool             _kalmanFitForward;
   int              _step;
   bool             _combine;
   bool             _build;
@@ -36,7 +37,7 @@ public:
       "CombineCollections", "ExtendTracks", "BuildNewTracks", "SortTracks",
   };
   const StringVec _existingFlags = {
-      "HighPTFit", "OnlyZSchi2cut", "RadialSearch", "VertexToTracker",
+      "HighPTFit", "OnlyZSchi2cut", "RadialSearch", "VertexToTracker", "KalmanFitForward", "KalmanFitBackward",
   };
   const StringVec _existingParameters = {
       "MaxCellAngle", "MaxCellAngleRZ", "Chi2Cut", "MinClustersOnTrack", "MaxDistance", "HighPTCut",
@@ -44,7 +45,8 @@ public:
 
   Parameters(std::vector<int> const& collections, double maxCellAngle, double maxCellAngleRZ, double chi2cut,
              int minClustersOnTrack, double maxDistance, double highPTcut, bool highPTfit, bool onlyZSchi2cut,
-             bool radialSearch, bool vertexToTracker, int step, bool combine, bool build, bool extend, bool sortTracks)
+             bool radialSearch, bool vertexToTracker, bool kalmanFitForward, int step, bool combine, bool build, bool extend,
+             bool sortTracks)
       : _collections(collections),
         _maxCellAngle(maxCellAngle),
         _maxCellAngleRZ(maxCellAngleRZ),
@@ -56,6 +58,7 @@ public:
         _onlyZSchi2cut(onlyZSchi2cut),
         _radialSearch(radialSearch),
         _vertexToTracker(vertexToTracker),
+        _kalmanFitForward(kalmanFitForward),
         _step(step),
         _combine(combine),
         _build(build),

--- a/source/test/TestConfig.cpp
+++ b/source/test/TestConfig.cpp
@@ -67,22 +67,22 @@ int main() {
     [VXDBarrel]
     @Collections : VXDTrackerHits
     @Parameters : MaxCellAngle : 0.035; MaxCellAngleRZ : 0.035;  Chi2Cut : 300;  MinClustersOnTrack : 5;  MaxDistance : 0.015
-    @Flags : HighPTFit, VertexToTracker
+    @Flags : HighPTFit, VertexToTracker, KalmanFitForward
     @Functions : CombineCollections, BuildNewTracks
     [VXDEncap]
     @Collections : VXDEndcapTrackerHits
     @Parameters : MaxCellAngle : 0.035 MaxCellAngleRZ : 0.035:  Chi2Cut : 300:  MinClustersOnTrack : 5   MaxDistance : 0.015
-    @Flags : HighPTFit, VertexToTracker
+    @Flags : HighPTFit, VertexToTracker, KalmanFitForward
     @Functions : CombineCollections, ExtendTracks
     [TCVC]
     @Collections : VXDTrackerHits, VXDEndcapTrackerHits
     @Parameters : MaxCellAngle : 0.035; MaxCellAngleRZ : 0.035;  Chi2Cut : 300;  MinClustersOnTrack : 5;  MaxDistance : 0.015
-    @Flags : HighPTFit, VertexToTracker;
+    @Flags : HighPTFit, VertexToTracker, KalmanFitForward
     @Functions : CombineCollections, BuildNewTracks
     [Foo]
     @Collections :
     @Parameters : MaxCellAngle : 0.035; MaxCellAngleRZ : 0.035;  Chi2Cut : 300;  MinClustersOnTrack : 5;  MaxDistance : 0.015
-    @Flags : HighPTFit, VertexToTracker;
+    @Flags : HighPTFit, VertexToTracker, KalmanFitBackward
     @Functions : BuildNewTracks
 )RAW";
 

--- a/src/KDTrack.C
+++ b/src/KDTrack.C
@@ -4,8 +4,14 @@
 #include "TH2F.h"
 
 // Constructor
-KDTrack::KDTrack()
-    : m_gradient(0.), m_intercept(0.), m_rotated(false), fillFit(false), m_nPoints(0), m_kalmanTrack(nullptr) {}
+KDTrack::KDTrack(Parameters const& par)
+    : m_gradient(0.),
+      m_intercept(0.),
+      m_rotated(false),
+      fillFit(false),
+      m_nPoints(0),
+      m_kalmanTrack(nullptr),
+      m_kalmanFitForward(par._kalmanFitForward) {}
 
 // Destructor
 KDTrack::~KDTrack() {}

--- a/src/Parameters.cc
+++ b/src/Parameters.cc
@@ -19,6 +19,7 @@ Parameters::Parameters(ParameterParser::ParsedParameters const& ps, std::vector<
       _onlyZSchi2cut(findEntry(ps._flags, "OnlyZSchi2cut")),
       _radialSearch(findEntry(ps._flags, "RadialSearch")),
       _vertexToTracker(findEntry(ps._flags, "VertexToTracker")),
+      _kalmanFitForward(findEntry(ps._flags, "KalmanFitForward") or not findEntry(ps._flags, "KalmanFitBackward")),
       _step(step),
       _combine(findEntry(ps._functions, "CombineCollections")),
       _build(findEntry(ps._functions, "BuildNewTracks")),


### PR DESCRIPTION
…f KDTrack class.



BEGINRELEASENOTES
 - ConfomalTrackingV2
    - Kalman fit direction can now be set per reconstruction step, to allow for the foreseen possibility to fit prompt tracks forward and non-prompt backward
    - added flag "KalmanFitBackward" and "KalmanFitForward" that can be parsed from steering file; if nothing is set, the default is forward 
 - Kalman fit direction added as member variable of the KDTrack class, with getter/setter

ENDRELEASENOTES