### PR TITLE
Extend tracks per layer

### DIFF
--- a/include/ConformalTracking.h
+++ b/include/ConformalTracking.h
@@ -242,7 +242,7 @@ inline bool sort_by_layer(SKDCluster const& hit1, SKDCluster const& hit2) {
 }
 
 // Sort kdhits by higher to lower layer number
-inline bool sort_by_lower_layer(SKDCluster const& hit1, SKDCluster const& hit2){
+inline bool sort_by_lower_layer(SKDCluster const& hit1, SKDCluster const& hit2) {
   if (hit1->getSubdetector() != hit2->getSubdetector())
     return (hit1->getSubdetector() > hit2->getSubdetector());
   else if (hit1->getLayer() != hit2->getLayer())

--- a/include/ConformalTracking.h
+++ b/include/ConformalTracking.h
@@ -79,6 +79,8 @@ public:
 
   void extendHighPT(UniqueKDTracks&, SharedKDClusters&, UKDTree&, Parameters const&, bool radialSearch = false);
 
+  void extendTracksPerLayer(UniqueKDTracks&, SharedKDClusters&, UKDTree&, Parameters const&, bool vertexToTracker = true);
+
   void createTracksNew(UniqueCellularTracks&, Cell::SCell&, std::map<Cell::SCell, bool>&);
   bool toBeUpdated(UniqueCellularTracks const&);
   void updateCell(Cell::SCell const&);
@@ -235,6 +237,18 @@ inline bool sort_by_layer(SKDCluster const& hit1, SKDCluster const& hit2) {
     return (hit1->getLayer() < hit2->getLayer());
   else if (hit1->getSide() != hit2->getSide())
     return (hit1->getSide() < hit2->getSide());
+  else
+    return false;
+}
+
+// Sort kdhits by higher to lower layer number
+inline bool sort_by_lower_layer(SKDCluster const& hit1, SKDCluster const& hit2){
+  if (hit1->getSubdetector() != hit2->getSubdetector())
+    return (hit1->getSubdetector() > hit2->getSubdetector());
+  else if (hit1->getLayer() != hit2->getLayer())
+    return (hit1->getLayer() > hit2->getLayer());
+  else if (hit1->getSide() != hit2->getSide())
+    return (hit1->getSide() > hit2->getSide());
   else
     return false;
 }

--- a/src/ConformalTracking.cc
+++ b/src/ConformalTracking.cc
@@ -1759,7 +1759,7 @@ void ConformalTracking::extendTracksPerLayer(UniqueKDTracks& conformalTracks, Sh
 
       // If no hit was found on a layer, we use expectedHit as current position
       // However, the nearest neighbour search is always performed from the last real hit (kdhit)
-      SKDCluster hitOnCurrentLayer = skipLayer ? expectedHit : kdhit;
+      const SKDCluster& hitOnCurrentLayer = skipLayer ? expectedHit : kdhit;
 
       // Set the subdetector layer in which to extend -- for this it is important that the hits are sorted by layer before
       // First layer is based on first neighbour

--- a/src/ConformalTracking.cc
+++ b/src/ConformalTracking.cc
@@ -1365,12 +1365,6 @@ void ConformalTracking::extendTracks(UniqueKDTracks& conformalTracks, SharedKDCl
         bestCluster = kdhit;
         bestChi2    = deltaChi2;
       }
-
-      //track->add(kdhit);
-      //kdhit->used(true);
-
-      // New hit has been added, go back to the beginning and start again...
-      // nKDHit = 0;
     }
 
     if (bestCluster != nullptr) {

--- a/src/ConformalTracking.cc
+++ b/src/ConformalTracking.cc
@@ -1721,7 +1721,7 @@ void ConformalTracking::extendTracksPerLayer(UniqueKDTracks& conformalTracks, Sh
                               << "[subdet,layer] = [" << kdhit->getSubdetector() << ", " << kdhit->getLayer() << "]" << std::endl;
       double theta = kdhit->getTheta();
       nearestNeighbours->allNeighboursInTheta(theta, m_thetaRange*4, results, [&kdhit, vertexToTracker](SKDCluster const& nhit) {
-        if ((vertexToTracker && nhit->getR() >= kdhit->getR()) || (!vertexToTracker && nhit->getR() <= kdhit->getR()))
+        if ((vertexToTracker && nhit->getR() > kdhit->getR()) || (!vertexToTracker && nhit->getR() < kdhit->getR()))
           return true;
         return false;
       });

--- a/src/ConformalTracking.cc
+++ b/src/ConformalTracking.cc
@@ -1972,8 +1972,9 @@ void ConformalTracking::extendTracksPerLayer(UniqueKDTracks& conformalTracks, Sh
                                   << "; radius = " << track->m_clusters.at(i)->getRadius() << std::endl;
           }
         }
+      }
       // If not bestCluster has been found in this layer, make cell with the expected hit (from extrapolation) and increment the missing hit count
-      } else {
+      else {
         streamlog_out(DEBUG9) << "- Found no bestCluster for [subdet,layer] = [" << extendInSubdet << ", " << extendInLayer
                               << "]" << std::endl;
         skipLayer = true;

--- a/src/ConformalTracking.cc
+++ b/src/ConformalTracking.cc
@@ -1901,8 +1901,10 @@ void ConformalTracking::extendTracksPerLayer(UniqueKDTracks& conformalTracks, Sh
         for(auto clu : bestClustersWithChi2){
 	  streamlog_out(DEBUG9) << "-- Best cluster candidate: [x,y] = [" << clu.first->getX() << ", " << clu.first->getY() << "]; r = " << clu.first->getR() << "; radius = " << clu.first->getRadius() << std::endl;
           streamlog_out(DEBUG9) << "-- chi " << clu.second << " compared to best chi " << bestChi2 << " of best candidate." << std::endl;
-	  if(clu.second < bestChi2 + chi2window && clu.second > bestChi2 - chi2window)
-	    bestClusters.push_back(clu.first); 
+	  if(clu.second < bestChi2 + chi2window && clu.second > bestChi2 - chi2window){
+            if(bestCluster != NULL && clu.first->sameSensor(bestCluster))
+	      bestClusters.push_back(clu.first); 
+          }
 	}
       }
       streamlog_out(DEBUG9) << "-- this seed cells will be updated with " << bestClusters.size() << " candidates." << std::endl;

--- a/src/ConformalTracking.cc
+++ b/src/ConformalTracking.cc
@@ -1225,7 +1225,7 @@ void ConformalTracking::extendTracks(UniqueKDTracks& conformalTracks, SharedKDCl
   std::sort(collection.begin(), collection.end(), sort_by_layer);
 
   // First extend high pt tracks
-  extendHighPT(conformalTracks, collection, nearestNeighbours, parameters);
+  extendTracksPerLayer(conformalTracks, collection, nearestNeighbours, parameters, parameters._vertexToTracker);
 
   // Mark hits from "good" tracks as being used
   for (auto& conformalTrack : conformalTracks) {
@@ -1688,6 +1688,11 @@ void ConformalTracking::extendTracksPerLayer(UniqueKDTracks& conformalTracks, Sh
 
     // Get the track
     UKDTrack& track = conformalTracks[currentTrack];
+
+    // Only look at high pt tracks
+    if (track->pt() < parameters._highPTcut)
+      continue;
+
     // Make sure that the hits are ordered in KDradius
     std::sort(track->m_clusters.begin(), track->m_clusters.end(),
               (vertexToTracker ? sort_by_radiusKD : sort_by_lower_radiusKD));
@@ -2871,8 +2876,7 @@ void ConformalTracking::runStep(SharedKDClusters& kdClusters, UKDTree& nearestNe
     stopwatch.Reset();
   }
   if (parameters._extend) {
-    //extendTracks(conformalTracks, kdClusters, nearestNeighbours, parameters);
-    extendTracksPerLayer(conformalTracks, kdClusters, nearestNeighbours, parameters, parameters._vertexToTracker);
+    extendTracks(conformalTracks, kdClusters, nearestNeighbours, parameters);
     stopwatch.Stop();
     streamlog_out(DEBUG7) << "Step " << parameters._step << "extendTracksPerLayer took " << stopwatch.RealTime()
                           << " seconds" << std::endl;

--- a/src/ConformalTracking.cc
+++ b/src/ConformalTracking.cc
@@ -1896,13 +1896,22 @@ void ConformalTracking::extendTracksPerLayer(UniqueKDTracks& conformalTracks, Sh
       } // end loop on neighbours
 
       streamlog_out(DEBUG9) << "-- this seed cells has " << bestClustersWithChi2.size() << " good candidates." << std::endl;
+
+      //put the best cluster already found
+      if(bestCluster != NULL){
+	bestClusters.push_back(bestCluster); 
+      }
+
+      //put all the other cluster with a similar chi2 - probably duplicates
       float chi2window = 100.0;
       if(bestClustersWithChi2.size()>0){
         for(auto clu : bestClustersWithChi2){
 	  streamlog_out(DEBUG9) << "-- Best cluster candidate: [x,y] = [" << clu.first->getX() << ", " << clu.first->getY() << "]; r = " << clu.first->getR() << "; radius = " << clu.first->getRadius() << std::endl;
           streamlog_out(DEBUG9) << "-- chi " << clu.second << " compared to best chi " << bestChi2 << " of best candidate." << std::endl;
 	  if(clu.second < bestChi2 + chi2window && clu.second > bestChi2 - chi2window){
-            if(bestCluster != NULL && clu.first->sameSensor(bestCluster))
+            if(clu.first->sameSensor(bestCluster))
+              streamlog_out(DEBUG9) << "-- current candidate and best one are in the same sensor " << std::endl;
+            if(bestCluster != NULL && !clu.first->sameSensor(bestCluster))
 	      bestClusters.push_back(clu.first); 
           }
 	}

--- a/src/ConformalTracking.cc
+++ b/src/ConformalTracking.cc
@@ -1733,6 +1733,14 @@ void ConformalTracking::extendTracksPerLayer(UniqueKDTracks& conformalTracks, Sh
       double theta = kdhit->getTheta();
       nearestNeighbours->allNeighboursInTheta(
           theta, m_thetaRange * 4, results, [&kdhit, vertexToTracker](SKDCluster const& nhit) {
+            //if same subdet, take only the hits within two layers
+            if (nhit->getSubdetector() == kdhit->getSubdetector()) {
+              if ((vertexToTracker && nhit->getLayer() > (kdhit->getLayer() + 2)) ||
+                  (!vertexToTracker && nhit->getLayer() < (kdhit->getLayer() - 2))) {
+                return true;
+              }
+            }
+
             if ((vertexToTracker && nhit->getR() > kdhit->getR()) || (!vertexToTracker && nhit->getR() < kdhit->getR()))
               return true;
             return false;
@@ -2878,8 +2886,8 @@ void ConformalTracking::runStep(SharedKDClusters& kdClusters, UKDTree& nearestNe
   if (parameters._extend) {
     extendTracks(conformalTracks, kdClusters, nearestNeighbours, parameters);
     stopwatch.Stop();
-    streamlog_out(DEBUG7) << "Step " << parameters._step << "extendTracksPerLayer took " << stopwatch.RealTime()
-                          << " seconds" << std::endl;
+    streamlog_out(DEBUG7) << "Step " << parameters._step << "extendTracks took " << stopwatch.RealTime() << " seconds"
+                          << std::endl;
     stopwatch.Reset();
   }
 

--- a/src/ConformalTracking.cc
+++ b/src/ConformalTracking.cc
@@ -843,7 +843,7 @@ void ConformalTracking::combineCollections(SharedKDClusters& kdClusters, UKDTree
 
   // Sort the KDClusters from larger to smaller radius
   std::sort(kdClusters.begin(), kdClusters.end(), sort_by_radiusKD);
- 
+
   // Make the binary search tree. This tree class contains two binary trees - one sorted by u-v and the other by theta
   nearestNeighbours = UKDTree(new KDTree(kdClusters, m_thetaRange, m_sortTreeResults));
 }
@@ -1667,13 +1667,14 @@ void ConformalTracking::extendHighPT(UniqueKDTracks& conformalTracks, SharedKDCl
   return;
 }
 
-// Take a collection of tracks and find the best extension layer by layer in the passed collection of clusters 
-void ConformalTracking::extendTracksPerLayer(UniqueKDTracks& conformalTracks, SharedKDClusters& collection, UKDTree& nearestNeighbours, 
-					     Parameters const& parameters, bool vertexToTracker){
+// Take a collection of tracks and find the best extension layer by layer in the passed collection of clusters
+void ConformalTracking::extendTracksPerLayer(UniqueKDTracks& conformalTracks, SharedKDClusters& collection,
+                                             UKDTree& nearestNeighbours, Parameters const& parameters,
+                                             bool vertexToTracker) {
+  streamlog_out(DEBUG9) << "*** extendTracksPerLayer: extending " << conformalTracks.size()
+                        << " tracks layer by layer, into " << collection.size() << " hits" << std::endl;
 
-  streamlog_out( DEBUG9 )  << "*** extendTracksPerLayer: extending " << conformalTracks.size() << " tracks layer by layer, into " << collection.size() << " hits" << std::endl;
-
-  if(collection.size() == 0)
+  if (collection.size() == 0)
     return;
 
   int nTracks = conformalTracks.size();
@@ -1682,269 +1683,297 @@ void ConformalTracking::extendTracksPerLayer(UniqueKDTracks& conformalTracks, Sh
   std::sort(collection.begin(), collection.end(), (vertexToTracker ? sort_by_layer : sort_by_lower_layer));
 
   // Loop over all tracks
-  for(int currentTrack = 0; currentTrack < nTracks; currentTrack++){
-    streamlog_out( DEBUG9 ) << "Track " << currentTrack << std::endl;
+  for (int currentTrack = 0; currentTrack < nTracks; currentTrack++) {
+    streamlog_out(DEBUG9) << "Track " << currentTrack << std::endl;
 
     // Get the track
     UKDTrack& track = conformalTracks[currentTrack];
     // Make sure that the hits are ordered in KDradius
-    std::sort(track->m_clusters.begin(), track->m_clusters.end(), (vertexToTracker ? sort_by_radiusKD : sort_by_lower_radiusKD));
+    std::sort(track->m_clusters.begin(), track->m_clusters.end(),
+              (vertexToTracker ? sort_by_radiusKD : sort_by_lower_radiusKD));
 
     // Make the cell from the two hits of the track from which to extend
     int nclusters = track->m_clusters.size();
-    streamlog_out( DEBUG9 ) << "Track has " << nclusters << " hits" << std::endl;
-    for(int i=0; i<nclusters; i++){
-      streamlog_out( DEBUG9 ) << "- Hit " << i << ": [x,y] = [" << track->m_clusters.at(i)->getX() << ", " << track->m_clusters.at(i)->getY() << "]" << std::endl;
+    streamlog_out(DEBUG9) << "Track has " << nclusters << " hits" << std::endl;
+    for (int i = 0; i < nclusters; i++) {
+      streamlog_out(DEBUG9) << "- Hit " << i << ": [x,y] = [" << track->m_clusters.at(i)->getX() << ", "
+                            << track->m_clusters.at(i)->getY() << "]" << std::endl;
     }
-    auto seedCell = std::make_shared<Cell>(track->m_clusters[nclusters-2],track->m_clusters[nclusters-1]);
-    streamlog_out(DEBUG9) << "Seed cell A ([x,y] = [" << track->m_clusters[nclusters-2]->getX() << "," << track->m_clusters[nclusters-2]->getY()
-			  <<"]) - B ([x,y] = [" << track->m_clusters[nclusters-1]->getX() << "," << track->m_clusters[nclusters-1]->getY() << "])" << std::endl;
+    auto seedCell = std::make_shared<Cell>(track->m_clusters[nclusters - 2], track->m_clusters[nclusters - 1]);
+    streamlog_out(DEBUG9) << "Seed cell A ([x,y] = [" << track->m_clusters[nclusters - 2]->getX() << ","
+                          << track->m_clusters[nclusters - 2]->getY() << "]) - B ([x,y] = ["
+                          << track->m_clusters[nclusters - 1]->getX() << "," << track->m_clusters[nclusters - 1]->getY()
+                          << "])" << std::endl;
 
     // Initialize variables for nearest neighbours search and subdetector layers
     SharedKDClusters results;
-    bool loop = true;
-    int extendInSubdet = 0;
-    int extendInLayer = 0;
-    int final_subdet = 0;
-    int final_layer = 0;
-    bool firstLayer = true;
-    bool skipLayer = false;
-    SKDCluster hitOnCurrentLayer = NULL;
-    SKDCluster expectedHit = NULL;
+    bool             loop              = true;
+    int              extendInSubdet    = 0;
+    int              extendInLayer     = 0;
+    int              final_subdet      = 0;
+    int              final_layer       = 0;
+    bool             firstLayer        = true;
+    bool             skipLayer         = false;
+    SKDCluster       hitOnCurrentLayer = NULL;
+    SKDCluster       expectedHit       = NULL;
 
     // Start the extension into input collection, layer by layer
-    do{
-      streamlog_out( DEBUG9 ) << "- Start extension" << std::endl;
+    do {
+      streamlog_out(DEBUG9) << "- Start extension" << std::endl;
       // Find nearest neighbours in theta and sort them by layer
       SKDCluster const& kdhit = seedCell->getEnd();
-      streamlog_out( DEBUG9 ) << "- Endpoint seed cell: [x,y] = [" << kdhit->getX() << ", " << kdhit->getY() << "]; " 
-                               << "]; r = " << kdhit->getR() << "; [subdet,layer] = [" << kdhit->getSubdetector() << ", " << kdhit->getLayer() << "]" << std::endl;
+      streamlog_out(DEBUG9) << "- Endpoint seed cell: [x,y] = [" << kdhit->getX() << ", " << kdhit->getY() << "]; "
+                            << "]; r = " << kdhit->getR() << "; [subdet,layer] = [" << kdhit->getSubdetector() << ", "
+                            << kdhit->getLayer() << "]" << std::endl;
       double theta = kdhit->getTheta();
-      nearestNeighbours->allNeighboursInTheta(theta, m_thetaRange*4, results, [&kdhit, vertexToTracker](SKDCluster const& nhit) {
-        if ((vertexToTracker && nhit->getR() > kdhit->getR()) || (!vertexToTracker && nhit->getR() < kdhit->getR()))
-          return true;
-        return false;
-      });
+      nearestNeighbours->allNeighboursInTheta(
+          theta, m_thetaRange * 4, results, [&kdhit, vertexToTracker](SKDCluster const& nhit) {
+            if ((vertexToTracker && nhit->getR() > kdhit->getR()) || (!vertexToTracker && nhit->getR() < kdhit->getR()))
+              return true;
+            return false;
+          });
       //nearestNeighbours->allNeighboursInRadius(kdhit, parameters._maxDistance, results);
-      streamlog_out( DEBUG9 ) << "- Found " << results.size() << " neighbours. " << std::endl;
-      if(streamlog::out.write<DEBUG9>()) {
-	      for(unsigned int neighbour = 0; neighbour < results.size(); neighbour++){
-	        streamlog_out( DEBUG9 ) << "-- Neighbour from allNeighboursInTheta " << neighbour << ": [x,y] = [" << results.at(neighbour)->getX() << ", " << results.at(neighbour)->getY() 
-				         << "]; r = " << results.at(neighbour)->getR() << "; [subdet,layer] = [" << results.at(neighbour)->getSubdetector() << ", " << results.at(neighbour)->getLayer() << "]" << std::endl;
-	      }
+      streamlog_out(DEBUG9) << "- Found " << results.size() << " neighbours. " << std::endl;
+      if (streamlog::out.write<DEBUG9>()) {
+        for (unsigned int neighbour = 0; neighbour < results.size(); neighbour++) {
+          streamlog_out(DEBUG9) << "-- Neighbour from allNeighboursInTheta " << neighbour << ": [x,y] = ["
+                                << results.at(neighbour)->getX() << ", " << results.at(neighbour)->getY()
+                                << "]; r = " << results.at(neighbour)->getR() << "; [subdet,layer] = ["
+                                << results.at(neighbour)->getSubdetector() << ", " << results.at(neighbour)->getLayer()
+                                << "]" << std::endl;
+        }
       }
 
-      if(results.size() == 0){
-	      loop=false;
-	      continue;
+      if (results.size() == 0) {
+        loop = false;
+        continue;
       }
 
-      std::sort(results.begin(), results.end(), (vertexToTracker ? sort_by_layer : sort_by_lower_layer)); 
+      std::sort(results.begin(), results.end(), (vertexToTracker ? sort_by_layer : sort_by_lower_layer));
       // Get the final values of subdet and layer to stop the loop at the (vertexToTracker? outermost : innermost) layer with neighbours
-      final_subdet = results.at(results.size()-1)->getSubdetector();
-      final_layer = results.at(results.size()-1)->getLayer();
-      streamlog_out( DEBUG9 ) << "- Final layer with neighbours: [subdet,layer] = [" << final_subdet << ", " << final_layer << "]" << std::endl;
-      
-      if(streamlog::out.write<DEBUG9>()) {
-	for(unsigned int neighbour = 0; neighbour < results.size(); neighbour++){
-	  streamlog_out( DEBUG9 ) << "-- Neighbour " << neighbour << ": [x,y] = [" << results.at(neighbour)->getX() << ", " << results.at(neighbour)->getY() 
-				  << "]; [subdet,layer] = [" << results.at(neighbour)->getSubdetector() << ", " << results.at(neighbour)->getLayer() << "]" << std::endl;
-	}
+      final_subdet = results.at(results.size() - 1)->getSubdetector();
+      final_layer  = results.at(results.size() - 1)->getLayer();
+      streamlog_out(DEBUG9) << "- Final layer with neighbours: [subdet,layer] = [" << final_subdet << ", " << final_layer
+                            << "]" << std::endl;
+
+      if (streamlog::out.write<DEBUG9>()) {
+        for (unsigned int neighbour = 0; neighbour < results.size(); neighbour++) {
+          streamlog_out(DEBUG9) << "-- Neighbour " << neighbour << ": [x,y] = [" << results.at(neighbour)->getX() << ", "
+                                << results.at(neighbour)->getY() << "]; [subdet,layer] = ["
+                                << results.at(neighbour)->getSubdetector() << ", " << results.at(neighbour)->getLayer()
+                                << "]" << std::endl;
+        }
       }
-      
+
       // If no hit was found on a layer, we use expectedHit as current position
       // However, the nearest neighbour search is always performed from the last real hit (kdhit)
-      if(!skipLayer) hitOnCurrentLayer = kdhit;
-      else hitOnCurrentLayer = expectedHit;
+      if (!skipLayer)
+        hitOnCurrentLayer = kdhit;
+      else
+        hitOnCurrentLayer = expectedHit;
 
       // Set the subdetector layer in which to extend -- for this it is important that the hits are sorted by layer before
       // First layer is based on first neighbour
       // Next layers are based on next wrt current
-      for(unsigned int neighbour = 0; neighbour < results.size(); neighbour++){
+      for (unsigned int neighbour = 0; neighbour < results.size(); neighbour++) {
+        streamlog_out(DEBUG9) << "-- Neighbour " << neighbour << ": [x,y] = [" << results.at(neighbour)->getX() << ", "
+                              << results.at(neighbour)->getY() << "]; [subdet,layer] = ["
+                              << results.at(neighbour)->getSubdetector() << ", " << results.at(neighbour)->getLayer() << "]"
+                              << std::endl;
 
-	streamlog_out( DEBUG9 ) << "-- Neighbour " << neighbour << ": [x,y] = [" << results.at(neighbour)->getX() << ", " << results.at(neighbour)->getY() 
-				<< "]; [subdet,layer] = [" << results.at(neighbour)->getSubdetector() << ", " << results.at(neighbour)->getLayer() << "]" << std::endl;
-
-	if(firstLayer){ // first neighbour
-	  extendInSubdet = results.at(0)->getSubdetector();
-	  extendInLayer = results.at(0)->getLayer();
-	  streamlog_out( DEBUG9 ) << "-- firstLayer) [subdet,layer] = [" << extendInSubdet << ", " << extendInLayer << "]" << std::endl;
-	  firstLayer = false;
-	  break;
-	}
-	else if(results.at(neighbour)->getSubdetector() == hitOnCurrentLayer->getSubdetector()){ // next layer is in same subdetector
-	  if( (vertexToTracker && (results.at(neighbour)->getLayer() > hitOnCurrentLayer->getLayer())) || (!vertexToTracker && (results.at(neighbour)->getLayer() < hitOnCurrentLayer->getLayer()))){ 
-	    extendInSubdet = results.at(neighbour)->getSubdetector();
-	    extendInLayer = results.at(neighbour)->getLayer();
-	    streamlog_out( DEBUG9 ) << "-- sameSub,diffLayer) [subdet,layer] = [" << extendInSubdet << ", " << extendInLayer << "]" << std::endl;
-	    break;
-	  }	  
-	}
-	else if((vertexToTracker && (results.at(neighbour)->getSubdetector() > hitOnCurrentLayer->getSubdetector())) || (!vertexToTracker && (results.at(neighbour)->getSubdetector() < hitOnCurrentLayer->getSubdetector()))){ // next layer is in next subdetector
-	  extendInSubdet = results.at(neighbour)->getSubdetector();
-	  extendInLayer = results.at(neighbour)->getLayer();
-	  streamlog_out( DEBUG9 ) << "-- diffSub) [subdet,layer] = [" << extendInSubdet << ", " << extendInLayer << "]" << std::endl;
-	  break;
-	}
-	else
-	  continue;
+        if (firstLayer) {  // first neighbour
+          extendInSubdet = results.at(0)->getSubdetector();
+          extendInLayer  = results.at(0)->getLayer();
+          streamlog_out(DEBUG9) << "-- firstLayer) [subdet,layer] = [" << extendInSubdet << ", " << extendInLayer << "]"
+                                << std::endl;
+          firstLayer = false;
+          break;
+        } else if (results.at(neighbour)->getSubdetector() ==
+                   hitOnCurrentLayer->getSubdetector()) {  // next layer is in same subdetector
+          if ((vertexToTracker && (results.at(neighbour)->getLayer() > hitOnCurrentLayer->getLayer())) ||
+              (!vertexToTracker && (results.at(neighbour)->getLayer() < hitOnCurrentLayer->getLayer()))) {
+            extendInSubdet = results.at(neighbour)->getSubdetector();
+            extendInLayer  = results.at(neighbour)->getLayer();
+            streamlog_out(DEBUG9) << "-- sameSub,diffLayer) [subdet,layer] = [" << extendInSubdet << ", " << extendInLayer
+                                  << "]" << std::endl;
+            break;
+          }
+        } else if ((vertexToTracker && (results.at(neighbour)->getSubdetector() > hitOnCurrentLayer->getSubdetector())) ||
+                   (!vertexToTracker && (results.at(neighbour)->getSubdetector() <
+                                         hitOnCurrentLayer->getSubdetector()))) {  // next layer is in next subdetector
+          extendInSubdet = results.at(neighbour)->getSubdetector();
+          extendInLayer  = results.at(neighbour)->getLayer();
+          streamlog_out(DEBUG9) << "-- diffSub) [subdet,layer] = [" << extendInSubdet << ", " << extendInLayer << "]"
+                                << std::endl;
+          break;
+        } else
+          continue;
       }
 
-      // Set the condition to end the loop 
-      if(extendInSubdet == final_subdet && extendInLayer == final_layer){ 
-	streamlog_out( DEBUG9 ) << "- Ending the loop. Reached final subdet layer" << std::endl;
-	loop = false;
+      // Set the condition to end the loop
+      if (extendInSubdet == final_subdet && extendInLayer == final_layer) {
+        streamlog_out(DEBUG9) << "- Ending the loop. Reached final subdet layer" << std::endl;
+        loop = false;
       }
 
       // Initialize variables for choosing the best neighbour in layer
       SKDCluster bestCluster = NULL;
-      map<SKDCluster,double> bestClustersWithChi2 = {};
+      map<SKDCluster, double> bestClustersWithChi2 = {};
       vector<SKDCluster> bestClusters = {};
-      double bestChi2 = 0.;
-      double chi2 = conformalTracks[currentTrack]->chi2ndof();
-      double chi2zs = conformalTracks[currentTrack]->chi2ndofZS();
-      UKDTrack& tempTrack = conformalTracks[currentTrack];
+      double             bestChi2     = 0.;
+      double             chi2         = conformalTracks[currentTrack]->chi2ndof();
+      double             chi2zs       = conformalTracks[currentTrack]->chi2ndofZS();
+      UKDTrack&          tempTrack    = conformalTracks[currentTrack];
 
       // Loop over neighbours
-      for(unsigned int neighbour = 0; neighbour < results.size(); neighbour++){
+      for (unsigned int neighbour = 0; neighbour < results.size(); neighbour++) {
+        SKDCluster& nhit = results[neighbour];
+        // only in the layer in which to extend
+        if (nhit->getSubdetector() == extendInSubdet && nhit->getLayer() == extendInLayer) {
+          // Store the hit in case no bestCluster will be found in this layer
+          expectedHit = nhit;
 
-	SKDCluster& nhit = results[neighbour];
-	// only in the layer in which to extend
-	if(nhit->getSubdetector() == extendInSubdet && nhit->getLayer() == extendInLayer){
+          streamlog_out(DEBUG9) << "-- Looking at neighbour " << neighbour << ": [x,y] = [" << nhit->getX() << ", "
+                                << nhit->getY() << "]" << std::endl;
 
-	  // Store the hit in case no bestCluster will be found in this layer
-	  expectedHit = nhit;
-      
-	  streamlog_out( DEBUG9 ) << "-- Looking at neighbour " << neighbour << ": [x,y] = [" << nhit->getX() << ", " << nhit->getY() << "]" << std::endl;
+          // Check that the hit has not been used
+          if (nhit->used()) {
+            streamlog_out(DEBUG9) << "-- used" << std::endl;
+            continue;
+          }
 
-	  // Check that the hit has not been used
-	  if(nhit->used()){
-	    streamlog_out(DEBUG9) << "-- used" << std::endl;
-	    continue;
-	  }
+          // Check that the hit is not in the opposite side of the detector (if endcap)
+          if (nhit->endcap() && kdhit->endcap() && (nhit->forward() != kdhit->forward())) {
+            streamlog_out(DEBUG9) << "-- opposite side of detector" << std::endl;
+            continue;
+          }
 
-	  // Check that the hit is not in the opposite side of the detector (if endcap)
-	  if (nhit->endcap() && kdhit->endcap() && (nhit->forward() != kdhit->forward())) {
-	    streamlog_out(DEBUG9) << "-- opposite side of detector" << std::endl;
-	    continue;
-	  }	
+          // Check that radial conditions are met
+          if ((vertexToTracker && nhit->getR() >= kdhit->getR()) || (!vertexToTracker && nhit->getR() <= kdhit->getR())) {
+            streamlog_out(DEBUG9) << "-- radial conditions not met" << std::endl;
+            continue;
+          }
 
-	  // Check that radial conditions are met
-	  if((vertexToTracker && nhit->getR() >= kdhit->getR()) || (!vertexToTracker && nhit->getR() <= kdhit->getR())){
-	    streamlog_out(DEBUG9) << "-- radial conditions not met" << std::endl;
-	    continue;
-	  }
+          // Check that the hit is not wildly away from the track (make cell and check angle)
+          Cell   extensionCell(conformalTracks[currentTrack]->m_clusters[nclusters - 1], nhit);
+          double cellAngle      = seedCell->getAngle(extensionCell);
+          double cellAngleRZ    = seedCell->getAngleRZ(extensionCell);
+          double maxCellAngle   = parameters._maxCellAngle;
+          double maxCellAngleRZ = parameters._maxCellAngleRZ;
 
-	  // Check that the hit is not wildly away from the track (make cell and check angle)
-	  Cell extensionCell(conformalTracks[currentTrack]->m_clusters[nclusters-1], nhit);
-	  double cellAngle = seedCell->getAngle(extensionCell);
-	  double cellAngleRZ = seedCell->getAngleRZ(extensionCell);
-	  double maxCellAngle = parameters._maxCellAngle;
-	  double maxCellAngleRZ = parameters._maxCellAngleRZ;
+          if (cellAngle > maxCellAngle || cellAngleRZ > maxCellAngleRZ) {
+            streamlog_out(DEBUG9) << "-- killed by cell angle cut" << std::endl;
+            continue;
+          }
 
-	  if(cellAngle > maxCellAngle || cellAngleRZ > maxCellAngleRZ){
-	    streamlog_out(DEBUG9) << "-- killed by cell angle cut" << std::endl;
-	    continue;
-	  }
+          // Now fit the track with the new hit and check the increase in chi2 - use a tempTrack object: add hit, fit, get chi2, remove hit
+          double deltaChi2(0.), deltaChi2zs(0.);
+          streamlog_out(DEBUG9) << "-- tempTrack has " << tempTrack->m_clusters.size() << " hits " << std::endl;
+          tempTrack->add(nhit);
+          tempTrack->linearRegression();
+          tempTrack->linearRegressionConformal();
+          double newchi2   = tempTrack->chi2ndof();
+          double newchi2zs = tempTrack->chi2ndofZS();
+          streamlog_out(DEBUG9) << "-- tempTrack has now " << tempTrack->m_clusters.size() << " hits " << std::endl;
+          deltaChi2   = fabs(newchi2 - chi2);
+          deltaChi2zs = fabs(newchi2zs - chi2zs);
+          streamlog_out(DEBUG9) << "-- hit was fitted and has a delta chi2 of " << deltaChi2 << " and delta chi2zs of "
+                                << deltaChi2zs << std::endl;
+          tempTrack->remove(tempTrack->m_clusters.size());
+          streamlog_out(DEBUG9) << "-- tempTrack has now " << tempTrack->m_clusters.size() << " hits " << std::endl;
 
-	  // Now fit the track with the new hit and check the increase in chi2 - use a tempTrack object: add hit, fit, get chi2, remove hit
-	  double deltaChi2(0.), deltaChi2zs(0.);
-	  streamlog_out(DEBUG9) << "-- tempTrack has " << tempTrack->m_clusters.size() << " hits " << std::endl;
-	  tempTrack->add(nhit);
-	  tempTrack->linearRegression();
-	  tempTrack->linearRegressionConformal();
-	  double newchi2 = tempTrack->chi2ndof();
-	  double newchi2zs = tempTrack->chi2ndofZS();
-	  streamlog_out(DEBUG9) << "-- tempTrack has now " << tempTrack->m_clusters.size() << " hits " << std::endl;
-	  deltaChi2 = fabs(newchi2 - chi2);
-	  deltaChi2zs = fabs(newchi2zs - chi2zs);
-	  streamlog_out(DEBUG9) << "-- hit was fitted and has a delta chi2 of " << deltaChi2 << " and delta chi2zs of " << deltaChi2zs << std::endl;
-	  tempTrack->remove(tempTrack->m_clusters.size());
-	  streamlog_out(DEBUG9) << "-- tempTrack has now " << tempTrack->m_clusters.size() << " hits " << std::endl;
+          double chi2cut = parameters._chi2cut;
+          if (deltaChi2 > chi2cut || deltaChi2zs > chi2cut) {
+            streamlog_out(DEBUG9) << "-- killed by chi2 cut" << std::endl;
+            continue;
+          }
+          streamlog_out(DEBUG9) << "-- valid candidate" << std::endl;
 
-	  double chi2cut = parameters._chi2cut;
-	  if(deltaChi2 > chi2cut || deltaChi2zs > chi2cut){
-	    streamlog_out(DEBUG9) << "-- killed by chi2 cut" << std::endl;
-	    continue;
-	  }
-	  streamlog_out(DEBUG9) << "-- valid candidate" << std::endl;
+          bestClustersWithChi2[nhit] = deltaChi2;
 
-	  bestClustersWithChi2[nhit] = deltaChi2;
+          // bestCluster still empty - fill it with the first candidate
+          if (bestCluster == NULL) {
+            bestCluster = nhit;
+            bestChi2    = deltaChi2;
+            //	    streamlog_out(DEBUG9) << "-- First candidate: [x,y] = [" << bestCluster->getX() << ", " << bestCluster->getY() << "], deltachi2 = " << bestChi2 << std::endl;
+          }
+          // bestCluster contains already a candidate
+          else {
+            if (deltaChi2 < bestChi2) {
+              bestCluster = nhit;
+              bestChi2    = deltaChi2;
+              //	      streamlog_out(DEBUG9) << "-- Best cluster updated: [x,y] = [" << bestCluster->getX() << ", " << bestCluster->getY() << "], deltachi2 = " << bestChi2 << std::endl;
 
-	  // bestCluster still empty - fill it with the first candidate
-	  if(bestCluster == NULL){ 
-	    bestCluster = nhit;
-	    bestChi2 = deltaChi2;
-//	    streamlog_out(DEBUG9) << "-- First candidate: [x,y] = [" << bestCluster->getX() << ", " << bestCluster->getY() << "], deltachi2 = " << bestChi2 << std::endl;
-	  }
-	  // bestCluster contains already a candidate
-	  else{
-	    if(deltaChi2 < bestChi2){
-	      bestCluster = nhit;
-	      bestChi2 = deltaChi2;
-//	      streamlog_out(DEBUG9) << "-- Best cluster updated: [x,y] = [" << bestCluster->getX() << ", " << bestCluster->getY() << "], deltachi2 = " << bestChi2 << std::endl;
+            } else {
+              //	      streamlog_out(DEBUG9) << "-- Best cluster unchanged: [x,y] = [" << bestCluster->getX() << ", " << bestCluster->getY() << "], deltachi2 = " << bestChi2 << std::endl;
+              continue;
+            }
+          }
 
-	    }
-	    else{
-//	      streamlog_out(DEBUG9) << "-- Best cluster unchanged: [x,y] = [" << bestCluster->getX() << ", " << bestCluster->getY() << "], deltachi2 = " << bestChi2 << std::endl;
-	      continue;
-	    }
-	  }
+        }  // end if on the extension layer
 
-	} // end if on the extension layer
-
-      } // end loop on neighbours
+      }  // end loop on neighbours
 
       streamlog_out(DEBUG9) << "-- this seed cells has " << bestClustersWithChi2.size() << " good candidates." << std::endl;
 
       //put the best cluster already found
-      if(bestCluster != NULL){
-	bestClusters.push_back(bestCluster); 
+      if (bestCluster != NULL) {
+        bestClusters.push_back(bestCluster);
       }
 
       //put all the other cluster with a similar chi2 - probably duplicates
       float chi2window = 100.0;
-      if(bestClustersWithChi2.size()>0){
-        for(auto clu : bestClustersWithChi2){
-	  streamlog_out(DEBUG9) << "-- Best cluster candidate: [x,y] = [" << clu.first->getX() << ", " << clu.first->getY() << "]; r = " << clu.first->getR() << "; radius = " << clu.first->getRadius() << std::endl;
-          streamlog_out(DEBUG9) << "-- chi " << clu.second << " compared to best chi " << bestChi2 << " of best candidate." << std::endl;
-	  if(clu.second < bestChi2 + chi2window && clu.second > bestChi2 - chi2window){
-            if(clu.first->sameSensor(bestCluster))
+      if (bestClustersWithChi2.size() > 0) {
+        for (auto clu : bestClustersWithChi2) {
+          streamlog_out(DEBUG9) << "-- Best cluster candidate: [x,y] = [" << clu.first->getX() << ", " << clu.first->getY()
+                                << "]; r = " << clu.first->getR() << "; radius = " << clu.first->getRadius() << std::endl;
+          streamlog_out(DEBUG9) << "-- chi " << clu.second << " compared to best chi " << bestChi2 << " of best candidate."
+                                << std::endl;
+          if (clu.second < bestChi2 + chi2window && clu.second > bestChi2 - chi2window) {
+            if (clu.first->sameSensor(bestCluster))
               streamlog_out(DEBUG9) << "-- current candidate and best one are in the same sensor " << std::endl;
-            if(bestCluster != NULL && !clu.first->sameSensor(bestCluster))
-	      bestClusters.push_back(clu.first); 
+            if (bestCluster != NULL && !clu.first->sameSensor(bestCluster))
+              bestClusters.push_back(clu.first);
           }
-	}
+        }
       }
-      streamlog_out(DEBUG9) << "-- this seed cells will be updated with " << bestClusters.size() << " candidates." << std::endl;
+      streamlog_out(DEBUG9) << "-- this seed cells will be updated with " << bestClusters.size() << " candidates."
+                            << std::endl;
       std::sort(bestClusters.begin(), bestClusters.end(), (vertexToTracker ? sort_by_radiusKD : sort_by_lower_radiusKD));
-     
+
       // If bestClusters have been found in this layer, add them to the track, update the seed cell and reset
-      if(!bestClusters.empty()){
-	skipLayer = false;
-	nclusters = conformalTracks[currentTrack]->m_clusters.size();
-	streamlog_out(DEBUG9) << "- nclusters = " << nclusters << std::endl;
-        for(int i=0; i<nclusters; i++){
-          streamlog_out( DEBUG9 ) << "- Hit " << i << ": [x,y] = [" << track->m_clusters.at(i)->getX() << ", " << track->m_clusters.at(i)->getY() << "]; r = " << track->m_clusters.at(i)->getR() << "; radius = " << track->m_clusters.at(i)->getRadius()  << std::endl;
+      if (!bestClusters.empty()) {
+        skipLayer = false;
+        nclusters = conformalTracks[currentTrack]->m_clusters.size();
+        streamlog_out(DEBUG9) << "- nclusters = " << nclusters << std::endl;
+        for (int i = 0; i < nclusters; i++) {
+          streamlog_out(DEBUG9) << "- Hit " << i << ": [x,y] = [" << track->m_clusters.at(i)->getX() << ", "
+                                << track->m_clusters.at(i)->getY() << "]; r = " << track->m_clusters.at(i)->getR()
+                                << "; radius = " << track->m_clusters.at(i)->getRadius() << std::endl;
         }
         //create new cell with last track cluster and last bestCluster
         //Best clusters are already ordered depending on vertexToTracker bool
-	seedCell = std::make_shared<Cell>(conformalTracks[currentTrack]->m_clusters[nclusters-1], bestClusters.at(bestClusters.size()-1));
-        streamlog_out(DEBUG9) << (skipLayer ? "- Still" : "- Updated") << " seed cell A ([x,y] = [" << seedCell->getStart()->getX() << ", " << seedCell->getStart()->getY()
-			      <<"]) - B ([x,y] = [" << seedCell->getEnd()->getX() << ", " << seedCell->getEnd()->getY() << ")]" << std::endl;
+        seedCell = std::make_shared<Cell>(conformalTracks[currentTrack]->m_clusters[nclusters - 1],
+                                          bestClusters.at(bestClusters.size() - 1));
+        streamlog_out(DEBUG9) << (skipLayer ? "- Still" : "- Updated") << " seed cell A ([x,y] = ["
+                              << seedCell->getStart()->getX() << ", " << seedCell->getStart()->getY() << "]) - B ([x,y] = ["
+                              << seedCell->getEnd()->getX() << ", " << seedCell->getEnd()->getY() << ")]" << std::endl;
 
-	for(auto bestClu : bestClusters){
-	  streamlog_out(DEBUG9) << "- Found bestCluster [x,y] = [" << bestClu->getX() << ", " << bestClu->getY() << "]; r = " << bestClu->getR()<< std::endl;
-	  conformalTracks[currentTrack]->add(bestClu);
-	  conformalTracks[currentTrack]->linearRegression();
-	  conformalTracks[currentTrack]->linearRegressionConformal();
-	  bestClu->used(true);
-	  nclusters = conformalTracks[currentTrack]->m_clusters.size();
-	  streamlog_out(DEBUG9) << "- nclusters = " << nclusters << std::endl;
-          for(int i=0; i<nclusters; i++){
-            streamlog_out( DEBUG9 ) << "- Hit " << i << ": [x,y] = [" << track->m_clusters.at(i)->getX() << ", " << track->m_clusters.at(i)->getY() << "]; r = " << track->m_clusters.at(i)->getR() << "; radius = " << track->m_clusters.at(i)->getRadius()  << std::endl;
+        for (auto bestClu : bestClusters) {
+          streamlog_out(DEBUG9) << "- Found bestCluster [x,y] = [" << bestClu->getX() << ", " << bestClu->getY()
+                                << "]; r = " << bestClu->getR() << std::endl;
+          conformalTracks[currentTrack]->add(bestClu);
+          conformalTracks[currentTrack]->linearRegression();
+          conformalTracks[currentTrack]->linearRegressionConformal();
+          bestClu->used(true);
+          nclusters = conformalTracks[currentTrack]->m_clusters.size();
+          streamlog_out(DEBUG9) << "- nclusters = " << nclusters << std::endl;
+          for (int i = 0; i < nclusters; i++) {
+            streamlog_out(DEBUG9) << "- Hit " << i << ": [x,y] = [" << track->m_clusters.at(i)->getX() << ", "
+                                  << track->m_clusters.at(i)->getY() << "]; r = " << track->m_clusters.at(i)->getR()
+                                  << "; radius = " << track->m_clusters.at(i)->getRadius() << std::endl;
           }
-	}
+        }
 /*
 	if(bestClusters.size()==1){
   	  if(vertexToTracker)
@@ -1960,31 +1989,35 @@ void ConformalTracking::extendTracksPerLayer(UniqueKDTracks& conformalTracks, Sh
 */      }
       // If not bestCluster has been found in this layer, make cell with the expected hit (from extrapolation) and increment the missing hit count
       else{
-        streamlog_out(DEBUG9) << "- Found no bestCluster for [subdet,layer] = [" << extendInSubdet << ", " << extendInLayer << "]" << std::endl;
-        skipLayer = true;
-        streamlog_out(DEBUG9) << (skipLayer ? "- Still" : "- Updated") << " seed cell A ([x,y] = [" << conformalTracks[currentTrack]->m_clusters[nclusters-2]->getX() << ", " << conformalTracks[currentTrack]->m_clusters[nclusters-2]->getY()
-			    <<"]) - B ([x,y] = [" << conformalTracks[currentTrack]->m_clusters[nclusters-1]->getX() << ", " << conformalTracks[currentTrack]->m_clusters[nclusters-1]->getY() << ")]" << std::endl;
-      }
+  streamlog_out(DEBUG9) << "- Found no bestCluster for [subdet,layer] = [" << extendInSubdet << ", " << extendInLayer << "]"
+                        << std::endl;
+  skipLayer = true;
+  streamlog_out(DEBUG9) << (skipLayer ? "- Still" : "- Updated") << " seed cell A ([x,y] = ["
+                        << conformalTracks[currentTrack]->m_clusters[nclusters - 2]->getX() << ", "
+                        << conformalTracks[currentTrack]->m_clusters[nclusters - 2]->getY() << "]) - B ([x,y] = ["
+                        << conformalTracks[currentTrack]->m_clusters[nclusters - 1]->getX() << ", "
+                        << conformalTracks[currentTrack]->m_clusters[nclusters - 1]->getY() << ")]" << std::endl;
+}
 
-      // Clear the neighbours tree
-      results.clear();
-      bestClustersWithChi2.clear();
-      bestClusters.clear();
+// Clear the neighbours tree
+results.clear();
+bestClustersWithChi2.clear();
+bestClusters.clear();
 
-
-    }while(loop); // end of track extension
+    } while (loop);  // end of track extension
 
     streamlog_out(DEBUG9) << "Track ends with " << conformalTracks[currentTrack]->m_clusters.size() << " hits" << std::endl;
     if (streamlog::out.write<DEBUG9>()) {
-      for(unsigned int i=0; i<conformalTracks[currentTrack]->m_clusters.size(); i++){
-	streamlog_out(DEBUG9) << "- Hit " << i << ": [x,y] = [" << conformalTracks[currentTrack]->m_clusters.at(i)->getX() << ", " << conformalTracks[currentTrack]->m_clusters.at(i)->getY() << "], [subdet,layer] = [" << conformalTracks[currentTrack]->m_clusters.at(i)->getSubdetector() << ", " << conformalTracks[currentTrack]->m_clusters.at(i)->getLayer() << "]" << std::endl;
+      for (unsigned int i = 0; i < conformalTracks[currentTrack]->m_clusters.size(); i++) {
+        streamlog_out(DEBUG9) << "- Hit " << i << ": [x,y] = [" << conformalTracks[currentTrack]->m_clusters.at(i)->getX()
+                              << ", " << conformalTracks[currentTrack]->m_clusters.at(i)->getY() << "], [subdet,layer] = ["
+                              << conformalTracks[currentTrack]->m_clusters.at(i)->getSubdetector() << ", "
+                              << conformalTracks[currentTrack]->m_clusters.at(i)->getLayer() << "]" << std::endl;
       }
     }
 
-  } // end loop on tracks
-
+  }  // end loop on tracks
 }
-
 
 //===================================
 // Cellular Track Functions
@@ -2841,8 +2874,8 @@ void ConformalTracking::runStep(SharedKDClusters& kdClusters, UKDTree& nearestNe
     //extendTracks(conformalTracks, kdClusters, nearestNeighbours, parameters);
     extendTracksPerLayer(conformalTracks, kdClusters, nearestNeighbours, parameters, parameters._vertexToTracker);
     stopwatch.Stop();
-    streamlog_out(DEBUG7) << "Step " << parameters._step << "extendTracksPerLayer took " << stopwatch.RealTime() << " seconds"
-                          << std::endl;
+    streamlog_out(DEBUG7) << "Step " << parameters._step << "extendTracksPerLayer took " << stopwatch.RealTime()
+                          << " seconds" << std::endl;
     stopwatch.Reset();
   }
 

--- a/src/KDTree.C
+++ b/src/KDTree.C
@@ -144,7 +144,7 @@ void KDTree::transformThetaResults(KDTreeResultVector& vec, SharedKDClusters& re
   KDTreeResultVector filtered;
   filtered.reserve(vec.size());
   for (auto const& entry : vec) {
-    if (filter(det[entry.idx])) {
+    if (filter(thetaLookup[arrayTheta[entry.idx][0]])) {
       continue;
     }
     filtered.push_back(entry);


### PR DESCRIPTION

BEGINRELEASENOTES
- Introduce `extendTracksPerLayer` function to find all the hits layer by layer
- Filter the neighbours that are in the wrong direction of the track and that are in layers too far
- The best candidates are inserted in the track if their chi2 is within a certain range, otherwise only the hit with the best chi2 is kept
- Results in the bbar show improved number of hits for tracks with pT > 1 GeV and basically unchanged for tracks with pT < 1 GeV

ENDRELEASENOTES