### PR TITLE
Fix fitError

### DIFF
--- a/include/ConformalTracking.h
+++ b/include/ConformalTracking.h
@@ -193,6 +193,7 @@ protected:
   double            m_maxDistance        = 0.0;
   double            m_highPTcut          = 0.0;
   int               m_minClustersOnTrack = 0;
+  int               m_maxHitsInvFit      = 0;
   bool              m_enableTCVC         = true;
   bool              m_debugPlots         = false;
   bool              m_retryTooManyTracks = true;


### PR DESCRIPTION

BEGINRELEASENOTES
- Solving bug introduced with the PR #47 : the `fitError` variable was overwritten even when the inverted fit was not better than the normal one.
- The maximum number of track hit to try the inverted fit is now a parameter.

ENDRELEASENOTES