### PR TITLE
Refactor input parameters and include min number of hits after KF

### DIFF
--- a/include/ConformalTracking.h
+++ b/include/ConformalTracking.h
@@ -190,7 +190,6 @@ protected:
   // Other constants
   double            m_thetaRange                 = 0.0;
   double            m_chi2cut                    = 0.0;
-  double            m_chi2increase               = 0.0;
   double            m_maxCellAngle               = 0.0;
   double            m_maxCellAngleRZ             = 0.0;
   double            m_maxDistance                = 0.0;

--- a/include/ConformalTracking.h
+++ b/include/ConformalTracking.h
@@ -40,6 +40,9 @@ public:
   // Initialisation - run at the beginning to start histograms, etc.
   virtual void init();
 
+  // Register input collections and parameters
+  void registerParameters();
+
   /// fill the vectors mapping collections to index
   void fillCollectionIndexVectors();
 
@@ -185,21 +188,22 @@ protected:
   TH3F* m_xyzDistribution = nullptr;
 
   // Other constants
-  double            m_thetaRange         = 0.0;
-  double            m_chi2cut            = 0.0;
-  double            m_chi2increase       = 0.0;
-  double            m_maxCellAngle       = 0.0;
-  double            m_maxCellAngleRZ     = 0.0;
-  double            m_maxDistance        = 0.0;
-  double            m_highPTcut          = 0.0;
-  int               m_minClustersOnTrack = 0;
-  int               m_maxHitsInvFit      = 0;
-  bool              m_enableTCVC         = true;
-  bool              m_debugPlots         = false;
-  bool              m_retryTooManyTracks = true;
-  bool              m_sortTreeResults    = true;
-  double            m_purity             = 0.0;
-  SKDCluster        debugSeed            = nullptr;
+  double            m_thetaRange                 = 0.0;
+  double            m_chi2cut                    = 0.0;
+  double            m_chi2increase               = 0.0;
+  double            m_maxCellAngle               = 0.0;
+  double            m_maxCellAngleRZ             = 0.0;
+  double            m_maxDistance                = 0.0;
+  double            m_highPTcut                  = 0.0;
+  int               m_minClustersOnTrack         = 0;
+  int               m_minClustersOnTrackAfterFit = 0;
+  int               m_maxHitsInvFit              = 0;
+  bool              m_enableTCVC                 = true;
+  bool              m_debugPlots                 = false;
+  bool              m_retryTooManyTracks         = true;
+  bool              m_sortTreeResults            = true;
+  double            m_purity                     = 0.0;
+  SKDCluster        debugSeed                    = nullptr;
   ConformalDebugger m_debugger{};
 };
 

--- a/src/ConformalTracking.cc
+++ b/src/ConformalTracking.cc
@@ -98,8 +98,6 @@ ConformalTracking::ConformalTracking() : Processor("ConformalTracking") {
   registerProcessorParameter("MinClustersOnTrack", "Minimum number of clusters to create a track in pattern recognition",
                              m_minClustersOnTrack, int(6));
 
-  registerProcessorParameter("MaxChi2Increase", "Chi2 increase when adding new hits to a track", m_chi2increase,
-                             double(10.));
   registerProcessorParameter("EnableTightCutsVertexCombined",
                              "Enabled tight cuts as first step of reconstruction in vertex b+e [TMP!!]", m_enableTCVC,
                              bool(true));

--- a/src/ConformalTrackingV2.cc
+++ b/src/ConformalTrackingV2.cc
@@ -20,36 +20,11 @@ ConformalTrackingV2::ConformalTrackingV2() : ConformalTracking("ConformalTrackin
   // Processor description
   _description = "ConformalTrackingV2 constructs tracks using a combined conformal mapping and cellular automaton approach.";
 
-  // Input collections - tracker hits
-  std::vector<std::string> inputTrackerHitCollections = {"VXDTrackerHits", "VXDEndcapTrackerHits", "ITrackerHits",
-                                                         "OTrackerHits",   "ITrackerEndcapHits",   "OTrackerEndcapHits"};
-  registerInputCollections(LCIO::TRACKERHITPLANE, "TrackerHitCollectionNames", "Name of the TrackerHit input collections",
-                           m_inputTrackerHitCollections, inputTrackerHitCollections);
-
-  // Debugging collections - MC particles and relation collections
-  registerInputCollection(LCIO::MCPARTICLE, "MCParticleCollectionName", "Name of the MCParticle input collection",
-                          m_inputParticleCollection, std::string("MCParticle"));
-  std::vector<std::string> inputRelationCollections = {"VXDTrackerHitRelations",          "VXDEndcapTrackerHitRelations",
-                                                       "InnerTrackerBarrelHitsRelations", "OuterTrackerBarrelHitsRelations",
-                                                       "InnerTrackerEndcapHitsRelations", "OuterTrackerEndcapHitsRelations"};
-  registerInputCollections(LCIO::LCRELATION, "RelationsNames", "Name of the TrackerHit relation collections",
-                           m_inputRelationCollections, inputRelationCollections);
-
-  // Output collections - tracks
-  registerOutputCollection(LCIO::TRACK, "SiTrackCollectionName", "Silicon track Collection Name", m_outputTrackCollection,
-                           std::string("CATracks"));
-  registerOutputCollection(LCIO::TRACKERHITPLANE, "DebugHits", "DebugHits", m_outputDebugHits, std::string("DebugHits"));
+  // Input collections and parameters
+  registerParameters();
 
   // Parameters for tracking
-  registerProcessorParameter("DebugPlots", "Plots for debugging the tracking", m_debugPlots, bool(false));
-  registerProcessorParameter("RetryTooManyTracks", "retry with tightened parameters, when too many tracks are being created",
-                             m_retryTooManyTracks, m_retryTooManyTracks);
-  registerProcessorParameter("SortTreeResults", "sort results from kdtree search", m_sortTreeResults, m_sortTreeResults);
   registerProcessorParameter("Steps", "Steps", m_rawSteps, m_rawSteps);
-
-  registerProcessorParameter("trackPurity", "Purity value used for checking if tracks are real or not", m_purity,
-                             double(0.75));
-  registerProcessorParameter("ThetaRange", "Angular range for initial cell seeding", m_thetaRange, double(0.1));
 }
 
 void ConformalTrackingV2::parseStepParameters() {


### PR DESCRIPTION
BEGINRELEASENOTES
- Set `MaxHitInvertedFit` to 0 as default, i.e. the inverted fit is tried only for tracks whose fit is invalid
- Reject tracks that after the Kalman Filter have less than `MinClustersOnTrackAfterFit`. The default value is set to 4.
- Put common input collections and parameters of `ConformalTracking` and `ConformalTrackingV2`
 in a separate function
- Parameter `MaxChi2Increase` removed, it was not used anywhere inside the processor

ENDRELEASENOTES