### PR TITLE
ConformalTracking: fix logic treating case of 'Too Many Tracks'

### DIFF
--- a/include/ConformalTracking.h
+++ b/include/ConformalTracking.h
@@ -210,6 +210,7 @@ protected:
   int               m_minClustersOnTrack         = 0;
   int               m_minClustersOnTrackAfterFit = 0;
   int               m_maxHitsInvFit              = 0;
+  int               m_tooManyTracks              = 5e5;
   bool              m_enableTCVC                 = true;
   bool              m_debugPlots                 = false;
   bool              m_debugTime                  = false;


### PR DESCRIPTION
thanks to @protopopescu for pointing out the problems with the RetryTooManyTracks logic

BEGINRELEASENOTES

- Add Parameter TooManyTracks to configure what is considered too many, defaults to 5e5
- Fix the abort logic so that after ten tries the event is actually skipped, or if retryTooManyTracks is False immediately, instead of never or until the number of created tracks is small enough

ENDRELEASENOTES