### PR TITLE
Make ConformalTracking to behave less diruptively on encountering too many tracks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+.vscode

--- a/src/ConformalTracking.cc
+++ b/src/ConformalTracking.cc
@@ -2988,13 +2988,13 @@ void ConformalTracking::runStep(SharedKDClusters& kdClusters, UKDTree& nearestNe
         buildNewTracks(conformalTracks, kdClusters, nearestNeighbours, thisParameters, parameters._radialSearch,
                        parameters._vertexToTracker);
       } catch (TooManyTracksException& e) {
-        streamlog_out(MESSAGE) << "caught too many tracks, tightening parameters" << std::endl;
-        caughtException = true;
-        thisParameters.tighten();
-        if (not m_retryTooManyTracks || thisParameters._tightenStep > 10) {
+        if (not m_retryTooManyTracks || thisParameters._tightenStep >= 10) {
           streamlog_out(ERROR) << "Skipping event" << std::endl;
           throw;
         }
+        streamlog_out(MESSAGE) << "caught too many tracks, tightening parameters" << std::endl;
+        thisParameters.tighten();
+        caughtException = true;
       }
     } while (caughtException);
 

--- a/src/ConformalTracking.cc
+++ b/src/ConformalTracking.cc
@@ -593,7 +593,12 @@ void ConformalTracking::processEvent(LCEvent* evt) {
   UKDTree          nearestNeighbours = nullptr;
 
   for (auto const& parameters : _stepParameters) {
-    runStep(kdClusters, nearestNeighbours, conformalTracks, collectionClusters, parameters);
+    try {
+      runStep(kdClusters, nearestNeighbours, conformalTracks, collectionClusters, parameters);
+    } catch (const TooManyTracksException& e) {
+      streamlog_out(ERROR) << "Too many tracks in step: " << parameters._step << " skipping further steps" << std::endl;
+      break;
+    }
     streamlog_out(DEBUG9) << "STEP " << parameters._step << ": nr tracks = " << conformalTracks.size() << std::endl;
     if (streamlog_level(DEBUG9)) {
       for (auto const& confTrack : conformalTracks) {


### PR DESCRIPTION
Before this, ConformalTracking would throw a SkipEventException resulting in further Marlin processors down the line to not be executed. However, when using Marlin processors from Gaudi with the k4MarlinWrapper, the expected behaviour of a failing processors is to (optionally warn and) emit its usual output collections. Otherwise PodioOutput crashes in the end...

BEGINRELEASENOTES
- Emit an error message and skip further steps when too many tracks are created instead of throwing a SkipEventException

ENDRELEASENOTES

I tested the changes locally and they solved https://github.com/key4hep/k4MarlinWrapper/issues/158 for me. The track pulss also did not change more than they do from run to run anyway so I hope I did not break anything.