### PR TITLE
Fix out of bounds erase in ConformalTracking

### DIFF
--- a/include/KDTrack.h
+++ b/include/KDTrack.h
@@ -5,6 +5,7 @@
 #include "Parameters.h"
 
 #include <cmath>
+#include <stdexcept>
 
 class TH2F;
 
@@ -35,6 +36,9 @@ public:
     m_nPoints++;
   }
   void remove(int clusterN) {
+    if(clusterN < 0 || clusterN >= int(m_clusters.size())) {
+      throw std::out_of_range("KDTrack::remove: clusterN out of range");
+    }
     m_clusters.erase(m_clusters.begin() + clusterN);
     m_nPoints--;
   }

--- a/src/ConformalTracking.cc
+++ b/src/ConformalTracking.cc
@@ -2049,7 +2049,7 @@ void ConformalTracking::extendTracksPerLayer(UniqueKDTracks& conformalTracks, Sh
           deltaChi2zs = newchi2zs - chi2zs;
           streamlog_out(DEBUG9) << "-- hit was fitted and has a delta chi2 of " << deltaChi2 << " and delta chi2zs of "
                                 << deltaChi2zs << std::endl;
-          tempTrack.remove(tempTrack.m_clusters.size());
+          tempTrack.remove(tempTrack.m_clusters.size() - 1);
           streamlog_out(DEBUG9) << "-- tempTrack has now " << tempTrack.m_clusters.size() << " hits " << std::endl;
 
           double chi2cut = parameters._chi2cut;


### PR DESCRIPTION
The intention is to remove a hit that was just added (see comment in the code a
few lines above), but remove will end up calling `std::vector::erase` for the
element that is after the last one. The definition is here:
https://github.com/iLCSoft/ConformalTracking/blob/master/include/KDTrack.h#L37
or basically

``` cpp
void remove(int clusterN) {
m_clusters.erase(m_clusters.begin() + clusterN);
}
```

Other alternatives like `tempTrack.m_clusters.pop_back();` are also possible, I
guess it's better to use the interface.

BEGINRELEASENOTES
- Fix out of bounds erase in ConformalTracking
- Throw an exception if removing something out of bounds

ENDRELEASENOTES

Tagging @Zehvogel since there may be some changes in tracking for CLD